### PR TITLE
Initialize Android project structure and architecture docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Gradle
+.gradle/
+build/
+app/build/
+
+# IntelliJ/Android Studio
+.idea/
+*.iml
+
+# Local configuration
+local.properties
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # ImmaginarIA
+
+ImmaginarIA is an experimental Android application where players build a collaborative story by exchanging short voice messages. The app transcribes the clips, arranges them into a coherent story with the help of a language model and generates images and narration for an illustrated storybook.
+
+## Repository Structure
+
+- `app/` – Android application module
+- `docs/` – Documentation and design notes
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the high level architecture.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.imaginar.ai'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.imaginar.ai"
+        minSdk 24
+        targetSdk 33
+        versionCode 1
+        versionName "0.1"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.activity:activity-compose:1.7.2'
+    implementation 'androidx.compose.ui:ui:1.5.0'
+    implementation 'androidx.compose.material:material:1.5.0'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.imaginar.ai">
+
+    <application
+        android:allowBackup="true"
+        android:label="ImmaginarIA"
+        android:supportsRtl="true">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/imaginar/ai/MainActivity.kt
+++ b/app/src/main/java/com/imaginar/ai/MainActivity.kt
@@ -1,0 +1,14 @@
+package com.imaginar.ai
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            // TODO: UI will be implemented here
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,38 @@
+# ImmaginarIA Architecture
+
+ImmaginarIA is an Android application that lets children collaborate on an improvised story by exchanging short voice messages. Once the story is complete the app assembles the audio snippets into a multimedia storybook using generative AI services.
+
+## Module Overview
+
+| Module | Responsibility |
+|--------|----------------|
+| `app` | Android entry module with activities, navigation and UI. |
+| `recorder` | Capture and store voice clips from each player. |
+| `session` | Maintain the ordered list of story pieces and enforce game rules. |
+| `transcriber` | Convert recorded audio into text. The implementation can call a local ASR engine or a remote API. |
+| `llm` | Communicate with an LLM service to clean up transcripts, enforce continuity between messages and build the storyboard. |
+| `image` | Generate an illustration for each storyboard element using a text-to-image model. |
+| `tts` | Produce narrated audio for the final story using a TTS engine. |
+| `storyviewer` | Render the illustrated and narrated story for playback. |
+
+## Data Flow
+
+1. **Recording** – Players take turns recording a short message. Each clip is stored locally and added to the session queue.
+2. **Transcription** – After a clip is recorded it is sent to the transcriber module to obtain text.
+3. **Story Assembly** – When the session ends the list of transcripts is sent to the LLM module. The LLM returns a structured storyboard that connects the clips.
+4. **Illustration** – For every storyboard item the image module requests an illustration from a generative model.
+5. **Narration** – The final story text is passed to the TTS module to generate audio narration.
+6. **Playback** – The storyviewer module presents the sequence of images and plays narration audio, letting users save or replay the story.
+
+## Tech Stack
+
+* Language: Kotlin
+* Architecture: MVVM with repository pattern
+* Build System: Gradle
+* External Services: ASR, Large Language Model, Image generation, Text-to-Speech
+
+## Future Work
+
+* Implement networking layer for authenticated API calls
+* Local caching of generated assets
+* Offline mode with on-device models

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'ImmaginarIA'
+include ':app'


### PR DESCRIPTION
## Summary
- set up initial Android project module using Gradle and placeholder MainActivity
- add high-level architecture documentation for storytelling app
- document repository layout and add basic build configuration

## Testing
- `gradle tasks` *(fails: Could not resolve dependencies, received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b17d1af3d88325952cab4ff6b275d4