### PR TITLE
docs: add build instructions for major platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,36 @@ ImmaginarIA is an experimental Android application where players build a collabo
 - `docs/` – Documentation and design notes
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the high level architecture.
+
+## Building
+
+The project is built with Gradle. You will need a Java Development Kit (JDK 17 or later)
+and the Android SDK or Android Studio. If the Gradle wrapper scripts (`gradlew` or
+`gradlew.bat`) are not present, install Gradle separately and replace the wrapper
+commands below with `gradle`.
+
+### Linux
+
+From the repository root run:
+
+```bash
+./gradlew assembleDebug
+```
+
+### macOS
+
+Run the same command as on Linux:
+
+```bash
+./gradlew assembleDebug
+```
+
+### Windows
+
+Use the batch script:
+
+```bat
+gradlew.bat assembleDebug
+```
+
+The resulting APK can be found in `app/build/outputs/apk/`.


### PR DESCRIPTION
## Summary
- document how to build the project on Linux, macOS, and Windows using Gradle

## Testing
- `./gradlew test` (fails: No such file or directory)
- `gradle test` (fails: Could not resolve com.android.tools.build:gradle:8.1.0, received status code 403)


------
https://chatgpt.com/codex/tasks/task_e_68b1807599748325882c57ffbbc4c1cd