### PR TITLE
Add localized story list UI with splash screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,12 @@ android {
         versionCode 1
         versionName "0.1"
     }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.0'
+    }
     buildTypes {
         release {
             minifyEnabled false
@@ -26,4 +32,5 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.7.2'
     implementation 'androidx.compose.ui:ui:1.5.0'
     implementation 'androidx.compose.material:material:1.5.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,9 +3,11 @@
 
     <application
         android:allowBackup="true"
-        android:label="ImmaginarIA"
+        android:label="@string/app_name"
         android:supportsRtl="true">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/immagineran/no/MainActivity.kt
+++ b/app/src/main/java/com/immagineran/no/MainActivity.kt
@@ -3,12 +3,89 @@ package com.immagineran.no
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import java.text.DateFormat
+import java.util.Date
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            // TODO: UI will be implemented here
+            var showSplash by remember { mutableStateOf(true) }
+            LaunchedEffect(Unit) {
+                delay(2000)
+                showSplash = false
+            }
+            if (showSplash) {
+                SplashScreen()
+            } else {
+                StoryListScreen(onStartSession = {
+                    val context = this@MainActivity
+                    val title = getString(
+                        R.string.default_story_title,
+                        DateFormat.getDateTimeInstance().format(Date())
+                    )
+                    val story = Story(id = System.currentTimeMillis(), title = title, content = "")
+                    StoryRepository.addStory(context, story)
+                })
+            }
+        }
+    }
+}
+
+@Composable
+fun SplashScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = stringResource(id = R.string.app_name), style = MaterialTheme.typography.h3)
+    }
+}
+
+@Composable
+fun StoryListScreen(onStartSession: () -> Unit) {
+    val context = LocalContext.current
+    var stories by remember { mutableStateOf(emptyList<Story>()) }
+    LaunchedEffect(Unit) {
+        stories = StoryRepository.getStories(context)
+    }
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(
+            text = stringResource(R.string.story_list_title),
+            style = MaterialTheme.typography.h5
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        if (stories.isEmpty()) {
+            Text(text = stringResource(R.string.no_stories))
+        } else {
+            LazyColumn(modifier = Modifier.weight(1f)) {
+                items(stories) { story ->
+                    Text(
+                        text = story.title,
+                        style = MaterialTheme.typography.body1,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
+        }
+        Button(
+            onClick = {
+                onStartSession()
+                stories = StoryRepository.getStories(context)
+            },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        ) {
+            Text(text = stringResource(R.string.start_new_session))
         }
     }
 }

--- a/app/src/main/java/com/immagineran/no/Story.kt
+++ b/app/src/main/java/com/immagineran/no/Story.kt
@@ -1,0 +1,1 @@
+data class Story(val id: Long, val title: String, val content: String)

--- a/app/src/main/java/com/immagineran/no/StoryRepository.kt
+++ b/app/src/main/java/com/immagineran/no/StoryRepository.kt
@@ -1,0 +1,44 @@
+package com.immagineran.no
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+
+object StoryRepository {
+    private const val FILE_NAME = "stories.json"
+
+    fun getStories(context: Context): List<Story> {
+        val file = File(context.filesDir, FILE_NAME)
+        if (!file.exists()) return emptyList()
+        val json = file.readText()
+        val array = JSONArray(json)
+        val result = mutableListOf<Story>()
+        for (i in 0 until array.length()) {
+            val obj = array.getJSONObject(i)
+            result.add(
+                Story(
+                    id = obj.getLong("id"),
+                    title = obj.getString("title"),
+                    content = obj.getString("content")
+                )
+            )
+        }
+        return result
+    }
+
+    fun addStory(context: Context, story: Story) {
+        val stories = getStories(context).toMutableList()
+        stories.add(story)
+        val array = JSONArray()
+        stories.forEach { s ->
+            val obj = JSONObject()
+            obj.put("id", s.id)
+            obj.put("title", s.title)
+            obj.put("content", s.content)
+            array.put(obj)
+        }
+        val file = File(context.filesDir, FILE_NAME)
+        file.writeText(array.toString())
+    }
+}

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="app_name">ImmaginarIA</string>
+    <string name="story_list_title">Vos histoires</string>
+    <string name="no_stories">Aucune histoire</string>
+    <string name="start_new_session">Commencer une nouvelle session</string>
+    <string name="default_story_title">Session commencée %1$s</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="app_name">ImmaginarIA</string>
+    <string name="story_list_title">Le tue storie</string>
+    <string name="no_stories">Nessuna storia</string>
+    <string name="start_new_session">Inizia una nuova sessione</string>
+    <string name="default_story_title">Sessione iniziata %1$s</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="app_name">ImmaginarIA</string>
+    <string name="story_list_title">Your Stories</string>
+    <string name="no_stories">No stories yet</string>
+    <string name="start_new_session">Start new session</string>
+    <string name="default_story_title">Session started %1$s</string>
+</resources>


### PR DESCRIPTION
## Summary
- Display splash screen then list stored stories with a button to start a new session
- Persist stories locally with a simple JSON-backed repository
- Localize UI strings for English, French and Italian

## Testing
- `gradle test` *(fails: Could not resolve artifacts, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b18792e8908325a5902ad2c81072d2