### PR TITLE
Add audio recording screen for story creation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'com.immagineran.no'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.immagineran.no"
         minSdk 24
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "0.1"
     }
@@ -19,6 +19,13 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.5.0'
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     buildTypes {
         release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.immagineran.no">
 
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
     <application
         android:allowBackup="true"
         android:label="@string/app_name"

--- a/app/src/main/java/com/immagineran/no/MainActivity.kt
+++ b/app/src/main/java/com/immagineran/no/MainActivity.kt
@@ -24,6 +24,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             var showSplash by remember { mutableStateOf(true) }
+            var showRecorder by remember { mutableStateOf(false) }
             LaunchedEffect(Unit) {
                 delay(2000)
                 showSplash = false
@@ -31,15 +32,26 @@ class MainActivity : ComponentActivity() {
             if (showSplash) {
                 SplashScreen()
             } else {
-                StoryListScreen(onStartSession = {
-                    val context = this@MainActivity
-                    val title = getString(
-                        R.string.default_story_title,
-                        DateFormat.getDateTimeInstance().format(Date())
-                    )
-                    val story = Story(id = System.currentTimeMillis(), title = title, content = "")
-                    StoryRepository.addStory(context, story)
-                })
+                if (showRecorder) {
+                    StoryCreationScreen(onDone = { segments ->
+                        val context = this@MainActivity
+                        val title = getString(
+                            R.string.default_story_title,
+                            DateFormat.getDateTimeInstance().format(Date())
+                        )
+                        val story = Story(
+                            id = System.currentTimeMillis(),
+                            title = title,
+                            content = "Recorded segments: ${segments.size}"
+                        )
+                        StoryRepository.addStory(context, story)
+                        showRecorder = false
+                    })
+                } else {
+                    StoryListScreen(onStartSession = {
+                        showRecorder = true
+                    })
+                }
             }
         }
     }

--- a/app/src/main/java/com/immagineran/no/Story.kt
+++ b/app/src/main/java/com/immagineran/no/Story.kt
@@ -1,1 +1,3 @@
+package com.immagineran.no
+
 data class Story(val id: Long, val title: String, val content: String)

--- a/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
@@ -1,0 +1,157 @@
+package com.immagineran.no
+
+import android.Manifest
+import android.media.MediaPlayer
+import android.media.MediaRecorder
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import java.io.File
+
+@Composable
+fun StoryCreationScreen(onDone: (List<File>) -> Unit) {
+    val context = LocalContext.current
+    var isRecording by remember { mutableStateOf(false) }
+    val segments = remember { mutableStateListOf<File>() }
+    var currentIndex by remember { mutableStateOf(-1) }
+    var recorder by remember { mutableStateOf<MediaRecorder?>(null) }
+    var player by remember { mutableStateOf<MediaPlayer?>(null) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            startRecording(
+                segments,
+                context,
+                currentIndex,
+                onRecorder = { recorder = it },
+                onStart = { isRecording = true },
+                onIndex = { currentIndex = it }
+            )
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Button(onClick = {
+            if (isRecording) {
+                stopRecording(recorder) { recorder = null }
+                isRecording = false
+                currentIndex = -1
+            } else {
+                val permission = Manifest.permission.RECORD_AUDIO
+                if (ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED) {
+                    startRecording(
+                        segments,
+                        context,
+                        currentIndex,
+                        onRecorder = { recorder = it },
+                        onStart = { isRecording = true },
+                        onIndex = { currentIndex = it }
+                    )
+                } else {
+                    permissionLauncher.launch(permission)
+                }
+            }
+        }) {
+            Text(text = if (isRecording) stringResource(R.string.stop) else stringResource(R.string.record))
+        }
+
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            itemsIndexed(segments) { index, file ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.segment_number, index + 1),
+                        modifier = Modifier.weight(1f)
+                    )
+                    Button(onClick = {
+                        playSegment(file, player) { player = it }
+                    }) {
+                        Text(stringResource(R.string.play))
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(onClick = {
+                        startRecording(
+                            segments,
+                            context,
+                            index,
+                            onRecorder = { recorder = it },
+                            onStart = { isRecording = true },
+                            onIndex = { currentIndex = it }
+                        )
+                    }) {
+                        Text(stringResource(R.string.re_record))
+                    }
+                }
+            }
+        }
+
+        Button(
+            onClick = { onDone(segments.toList()) },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        ) {
+            Text(stringResource(R.string.done))
+        }
+    }
+}
+
+private fun startRecording(
+    segments: MutableList<File>,
+    context: android.content.Context,
+    index: Int,
+    onRecorder: (MediaRecorder) -> Unit,
+    onStart: () -> Unit,
+    onIndex: (Int) -> Unit = {}
+) {
+    val file = File(context.filesDir, "segment_${System.currentTimeMillis()}.m4a")
+    if (index >= 0 && index < segments.size) {
+        segments[index].delete()
+        segments[index] = file
+        onIndex(index)
+    } else {
+        segments.add(file)
+        onIndex(segments.lastIndex)
+    }
+    val rec = MediaRecorder()
+    rec.setAudioSource(MediaRecorder.AudioSource.MIC)
+    rec.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+    rec.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+    rec.setOutputFile(file.absolutePath)
+    rec.prepare()
+    rec.start()
+    onRecorder(rec)
+    onStart()
+}
+
+private fun stopRecording(recorder: MediaRecorder?, onRelease: () -> Unit) {
+    recorder?.run {
+        stop()
+        release()
+    }
+    onRelease()
+}
+
+private fun playSegment(file: File, currentPlayer: MediaPlayer?, onPlayer: (MediaPlayer) -> Unit) {
+    currentPlayer?.release()
+    val mp = MediaPlayer()
+    mp.setDataSource(file.absolutePath)
+    mp.prepare()
+    mp.start()
+    onPlayer(mp)
+}
+

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -4,4 +4,10 @@
     <string name="no_stories">Aucune histoire</string>
     <string name="start_new_session">Commencer une nouvelle session</string>
     <string name="default_story_title">Session commencée %1$s</string>
+    <string name="record">Enregistrer</string>
+    <string name="stop">Arrêter</string>
+    <string name="play">Lire</string>
+    <string name="re_record">Réenregistrer</string>
+    <string name="done">Terminer</string>
+    <string name="segment_number">Segment %1$d</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -4,4 +4,10 @@
     <string name="no_stories">Nessuna storia</string>
     <string name="start_new_session">Inizia una nuova sessione</string>
     <string name="default_story_title">Sessione iniziata %1$s</string>
+    <string name="record">Registra</string>
+    <string name="stop">Ferma</string>
+    <string name="play">Riproduci</string>
+    <string name="re_record">Riregistra</string>
+    <string name="done">Fatto</string>
+    <string name="segment_number">Segmento %1$d</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,10 @@
     <string name="no_stories">No stories yet</string>
     <string name="start_new_session">Start new session</string>
     <string name="default_story_title">Session started %1$s</string>
+    <string name="record">Record</string>
+    <string name="stop">Stop</string>
+    <string name="play">Play</string>
+    <string name="re_record">Re-record</string>
+    <string name="done">Done</string>
+    <string name="segment_number">Segment %1$d</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0'
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- add simple StoryCreationScreen to record audio segments with playback and re-record controls
- wire MainActivity to the new recording flow
- configure project for AndroidX and updated SDK levels

## Testing
- `gradle assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68b18adfdc98832596699c157c77e485