### PR TITLE
Organize stories into processed and resumable sessions

### DIFF
--- a/app/src/main/java/com/immagineran/no/MainActivity.kt
+++ b/app/src/main/java/com/immagineran/no/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import java.io.File
 import java.text.DateFormat
 import java.util.Date
 
@@ -25,6 +26,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             var showSplash by remember { mutableStateOf(true) }
             var showRecorder by remember { mutableStateOf(false) }
+            var storyToResume by remember { mutableStateOf<Story?>(null) }
             LaunchedEffect(Unit) {
                 delay(2000)
                 showSplash = false
@@ -33,24 +35,44 @@ class MainActivity : ComponentActivity() {
                 SplashScreen()
             } else {
                 if (showRecorder) {
-                    StoryCreationScreen(onDone = { segments ->
-                        val context = this@MainActivity
-                        val title = getString(
-                            R.string.default_story_title,
-                            DateFormat.getDateTimeInstance().format(Date())
-                        )
-                        val story = Story(
-                            id = System.currentTimeMillis(),
-                            title = title,
-                            content = "Recorded segments: ${segments.size}"
-                        )
-                        StoryRepository.addStory(context, story)
-                        showRecorder = false
-                    })
+                    StoryCreationScreen(
+                        initialSegments = storyToResume?.segments?.map { File(it) } ?: emptyList(),
+                        onDone = { segments ->
+                            val context = this@MainActivity
+                            if (storyToResume != null) {
+                                val updated = storyToResume!!.copy(
+                                    segments = segments.map { it.absolutePath }
+                                )
+                                StoryRepository.updateStory(context, updated)
+                                storyToResume = null
+                            } else {
+                                val title = getString(
+                                    R.string.default_story_title,
+                                    DateFormat.getDateTimeInstance().format(Date())
+                                )
+                                val story = Story(
+                                    id = System.currentTimeMillis(),
+                                    title = title,
+                                    content = "",
+                                    segments = segments.map { it.absolutePath },
+                                    processed = false
+                                )
+                                StoryRepository.addStory(context, story)
+                            }
+                            showRecorder = false
+                        }
+                    )
                 } else {
-                    StoryListScreen(onStartSession = {
-                        showRecorder = true
-                    })
+                    StoryListScreen(
+                        onStartSession = {
+                            storyToResume = null
+                            showRecorder = true
+                        },
+                        onResumeStory = { story ->
+                            storyToResume = story
+                            showRecorder = true
+                        }
+                    )
                 }
             }
         }
@@ -65,11 +87,14 @@ fun SplashScreen() {
 }
 
 @Composable
-fun StoryListScreen(onStartSession: () -> Unit) {
+fun StoryListScreen(onStartSession: () -> Unit, onResumeStory: (Story) -> Unit) {
     val context = LocalContext.current
-    var stories by remember { mutableStateOf(emptyList<Story>()) }
+    var processed by remember { mutableStateOf(emptyList<Story>()) }
+    var pending by remember { mutableStateOf(emptyList<Story>()) }
     LaunchedEffect(Unit) {
-        stories = StoryRepository.getStories(context)
+        val stories = StoryRepository.getStories(context)
+        processed = stories.filter { it.processed }
+        pending = stories.filter { !it.processed }
     }
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text(
@@ -77,24 +102,63 @@ fun StoryListScreen(onStartSession: () -> Unit) {
             style = MaterialTheme.typography.h5
         )
         Spacer(modifier = Modifier.height(8.dp))
-        if (stories.isEmpty()) {
-            Text(text = stringResource(R.string.no_stories))
-        } else {
-            LazyColumn(modifier = Modifier.weight(1f)) {
-                items(stories) { story ->
-                    Text(
-                        text = story.title,
-                        style = MaterialTheme.typography.body1,
-                        modifier = Modifier.padding(vertical = 4.dp)
-                    )
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            item {
+                Text(
+                    text = stringResource(R.string.unprocessed_stories_title),
+                    style = MaterialTheme.typography.h6,
+                )
+            }
+            if (pending.isEmpty()) {
+                item { Text(text = stringResource(R.string.no_unprocessed_stories)) }
+            } else {
+                items(pending) { story ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                    ) {
+                        Text(text = story.title, modifier = Modifier.weight(1f))
+                        Button(onClick = { onResumeStory(story) }) {
+                            Text(text = stringResource(R.string.resume))
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(onClick = {
+                            StoryRepository.deleteStory(context, story)
+                            pending = pending.filter { it.id != story.id }
+                        }) {
+                            Text(text = stringResource(R.string.delete))
+                        }
+                    }
+                }
+            }
+            item { Spacer(modifier = Modifier.height(16.dp)) }
+            item {
+                Text(
+                    text = stringResource(R.string.processed_stories_title),
+                    style = MaterialTheme.typography.h6,
+                )
+            }
+            if (processed.isEmpty()) {
+                item { Text(text = stringResource(R.string.no_stories)) }
+            } else {
+                items(processed) { story ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                    ) {
+                        Text(text = story.title, modifier = Modifier.weight(1f))
+                        Button(onClick = {
+                            StoryRepository.deleteStory(context, story)
+                            processed = processed.filter { it.id != story.id }
+                        }) {
+                            Text(text = stringResource(R.string.delete))
+                        }
+                    }
                 }
             }
         }
         Button(
-            onClick = {
-                onStartSession()
-                stories = StoryRepository.getStories(context)
-            },
+            onClick = { onStartSession() },
             modifier = Modifier.align(Alignment.CenterHorizontally)
         ) {
             Text(text = stringResource(R.string.start_new_session))

--- a/app/src/main/java/com/immagineran/no/Story.kt
+++ b/app/src/main/java/com/immagineran/no/Story.kt
@@ -1,3 +1,9 @@
 package com.immagineran.no
 
-data class Story(val id: Long, val title: String, val content: String)
+data class Story(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val segments: List<String> = emptyList(),
+    val processed: Boolean = false
+)

--- a/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
@@ -21,10 +21,10 @@ import androidx.core.content.ContextCompat
 import java.io.File
 
 @Composable
-fun StoryCreationScreen(onDone: (List<File>) -> Unit) {
+fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List<File>) -> Unit) {
     val context = LocalContext.current
     var isRecording by remember { mutableStateOf(false) }
-    val segments = remember { mutableStateListOf<File>() }
+    val segments = remember { mutableStateListOf<File>().apply { addAll(initialSegments) } }
     var currentIndex by remember { mutableStateOf(-1) }
     var recorder by remember { mutableStateOf<MediaRecorder?>(null) }
     var player by remember { mutableStateOf<MediaPlayer?>(null) }

--- a/app/src/main/java/com/immagineran/no/StoryRepository.kt
+++ b/app/src/main/java/com/immagineran/no/StoryRepository.kt
@@ -16,11 +16,20 @@ object StoryRepository {
         val result = mutableListOf<Story>()
         for (i in 0 until array.length()) {
             val obj = array.getJSONObject(i)
+            val segmentsArray = obj.optJSONArray("segments")
+            val segments = mutableListOf<String>()
+            if (segmentsArray != null) {
+                for (j in 0 until segmentsArray.length()) {
+                    segments.add(segmentsArray.getString(j))
+                }
+            }
             result.add(
                 Story(
                     id = obj.getLong("id"),
                     title = obj.getString("title"),
-                    content = obj.getString("content")
+                    content = obj.optString("content", ""),
+                    segments = segments,
+                    processed = obj.optBoolean("processed", false)
                 )
             )
         }
@@ -30,12 +39,50 @@ object StoryRepository {
     fun addStory(context: Context, story: Story) {
         val stories = getStories(context).toMutableList()
         stories.add(story)
+        saveStories(context, stories)
+    }
+
+    fun updateStory(context: Context, story: Story) {
+        val stories = getStories(context).toMutableList()
+        val index = stories.indexOfFirst { it.id == story.id }
+        if (index >= 0) {
+            stories[index] = story
+        } else {
+            stories.add(story)
+        }
+        saveStories(context, stories)
+    }
+
+    fun deleteStory(context: Context, story: Story) {
+        // Remove associated files
+        story.segments.forEach { path ->
+            try {
+                File(path).delete()
+            } catch (_: Exception) {
+                // Ignore failures deleting segment files
+            }
+        }
+        // Remove any directory named after the story id
+        val dir = File(context.filesDir, story.id.toString())
+        if (dir.exists()) {
+            dir.deleteRecursively()
+        }
+
+        val stories = getStories(context).filter { it.id != story.id }
+        saveStories(context, stories)
+    }
+
+    private fun saveStories(context: Context, stories: List<Story>) {
         val array = JSONArray()
         stories.forEach { s ->
             val obj = JSONObject()
             obj.put("id", s.id)
             obj.put("title", s.title)
             obj.put("content", s.content)
+            obj.put("processed", s.processed)
+            val segmentsArray = JSONArray()
+            s.segments.forEach { segmentsArray.put(it) }
+            obj.put("segments", segmentsArray)
             array.put(obj)
         }
         val file = File(context.filesDir, FILE_NAME)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,9 @@
     <string name="re_record">Re-record</string>
     <string name="done">Done</string>
     <string name="segment_number">Segment %1$d</string>
+    <string name="unprocessed_stories_title">Recorded Sessions</string>
+    <string name="processed_stories_title">Finished Stories</string>
+    <string name="resume">Resume</string>
+    <string name="no_unprocessed_stories">No recorded sessions</string>
+    <string name="delete">Delete</string>
 </resources>


### PR DESCRIPTION
## Summary
- Distinguish between processed stories and recorded sessions
- Allow resuming unprocessed recordings on the main screen
- Persist segment paths and processed status for each story
- Enable deleting stories along with their recorded files

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b1998a99688325b6845d3f5cf1f1ba