### PR TITLE
Transcribe recorded segments with SpeechRecognizer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.immagineran.no">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,4 +10,7 @@
     <string name="re_record">Réenregistrer</string>
     <string name="done">Terminer</string>
     <string name="segment_number">Segment %1$d</string>
+    <string name="transcribing">Transcription…</string>
+    <string name="transcription_failed">Échec de la transcription</string>
+    <string name="transcription_label">Transcription : %1$s</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -10,4 +10,7 @@
     <string name="re_record">Riregistra</string>
     <string name="done">Fatto</string>
     <string name="segment_number">Segmento %1$d</string>
+    <string name="transcribing">Trascrizione…</string>
+    <string name="transcription_failed">Trascrizione fallita</string>
+    <string name="transcription_label">Trascrizione: %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,7 @@
     <string name="resume">Resume</string>
     <string name="no_unprocessed_stories">No recorded sessions</string>
     <string name="delete">Delete</string>
+    <string name="transcribing">Transcribing…</string>
+    <string name="transcription_failed">Transcription failed</string>
+    <string name="transcription_label">Transcription: %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- transcribe each recorded segment in the background using Android's `SpeechRecognizer`
- display the resulting text below its segment on the recording screen
- add translation strings and network permission for speech recognition

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68b1a921e56483258cc238a82bc50b8c