### PR TITLE
chore: add Firebase App Distribution workflow

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -1,0 +1,29 @@
+name: Distribute to Firebase App Distribution
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+      - name: Upload to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          groups: ${{ secrets.FIREBASE_TESTERS_GROUPS }}
+          file: app/build/outputs/apk/release/app-release.apk
+

--- a/README.md
+++ b/README.md
@@ -40,3 +40,10 @@ gradlew.bat assembleDebug
 ```
 
 The resulting APK can be found in `app/build/outputs/apk/`.
+
+## Deployment
+
+Release builds can be automatically distributed to testers through Firebase App Distribution.
+The GitHub Actions workflow in `.github/workflows/firebase-app-distribution.yml` builds the
+release APK and uploads it whenever a tag starting with `v` is pushed.
+Refer to [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for configuration details.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,16 @@
+# Deployment
+
+This project uses GitHub Actions to automatically distribute release builds to Firebase App Distribution.
+Pushing a Git tag that starts with `v` triggers the workflow. The action builds the release APK and uploads it to the testers group in Firebase.
+
+## Configuration
+
+1. Generate a Firebase service account with access to App Distribution and download the JSON credentials.
+2. In the repository settings add the following secrets:
+   - `FIREBASE_SERVICE_ACCOUNT` – contents of the service account JSON file.
+   - `FIREBASE_APP_ID` – the Firebase App ID for the Android application.
+   - `FIREBASE_TESTERS_GROUPS` – comma-separated list of tester groups or e-mail addresses that should receive builds.
+
+## Manual trigger
+
+The workflow also exposes a manual trigger from the GitHub Actions tab via **Run workflow**. This lets you distribute a build without pushing a new tag.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and upload releases to Firebase App Distribution
- document Firebase App Distribution deployment and link from README

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c09f0a7c8325bbbf56868e528ab8