### PR TITLE
Sign release build for Firebase distribution

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -19,6 +19,9 @@ jobs:
           distribution: 'temurin'
           java-version: 17
 
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
       - name: Build release APK
         run: ./gradlew assembleRelease
           

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
+            signingConfig signingConfigs.debug
         }
     }
 }


### PR DESCRIPTION
## Summary
- sign release builds with debug keystore so a `app-release.apk` is produced
- ensure workflow has executable gradlew before building

## Testing
- `./gradlew assembleRelease`


------
https://chatgpt.com/codex/tasks/task_e_68b1fa7ab52c8325a400d7e1aa586554