### PR TITLE
Integrate Firebase Crashlytics

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Set up google-services.json
+        run: |
+          cat <<'EOF' > app/google-services.json
+          ${{ secrets.GOOGLE_SERVICES_JSON }}
+          EOF
+
       - name: Build release APK
         run: ./gradlew assembleRelease
           

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'com.google.firebase.crashlytics'
+    id 'com.google.gms.google-services'
 }
 
 android {
@@ -41,4 +43,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui:1.5.0'
     implementation 'androidx.compose.material:material:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation platform('com.google.firebase:firebase-bom:32.3.1')
+    implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation 'com.google.firebase:firebase-analytics-ktx'
 }

--- a/app/src/main/java/com/immagineran/no/MainActivity.kt
+++ b/app/src/main/java/com/immagineran/no/MainActivity.kt
@@ -19,10 +19,12 @@ import kotlinx.coroutines.delay
 import java.io.File
 import java.text.DateFormat
 import java.util.Date
+import com.google.firebase.FirebaseApp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        FirebaseApp.initializeApp(this)
         setContent {
             var showSplash by remember { mutableStateOf(true) }
             var showRecorder by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import java.io.File
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 
 @Composable
 fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List<File>) -> Unit) {
@@ -206,6 +207,8 @@ private fun transcribeSegment(
         }
 
         override fun onError(error: Int) {
+            FirebaseCrashlytics.getInstance()
+                .recordException(Exception("SpeechRecognizer error code: $error"))
             transcriptions[index] = context.getString(R.string.transcription_failed)
             recognizer.destroy()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.2'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
+        classpath 'com.google.gms:google-services:4.3.15'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
     }
 }
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,6 +10,7 @@ Pushing a Git tag that starts with `v` triggers the workflow. The action builds 
    - `FIREBASE_SERVICE_ACCOUNT` – contents of the service account JSON file.
    - `FIREBASE_APP_ID` – the Firebase App ID for the Android application.
    - `FIREBASE_TESTERS_GROUPS` – comma-separated list of tester groups or e-mail addresses that should receive builds.
+   - `GOOGLE_SERVICES_JSON` – contents of the `google-services.json` configuration file used by Firebase.
 
 ## Manual trigger
 


### PR DESCRIPTION
## Summary
- add Crashlytics and Google services Gradle plugins
- log SpeechRecognizer errors to Firebase Crashlytics
- prepare google-services.json from secrets during CI build

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68b1fe32e8788325aeb2d57c023b61fc