### PR TITLE
Add test crash button to main UI

### DIFF
--- a/app/src/main/java/com/immagineran/no/MainActivity.kt
+++ b/app/src/main/java/com/immagineran/no/MainActivity.kt
@@ -165,5 +165,12 @@ fun StoryListScreen(onStartSession: () -> Unit, onResumeStory: (Story) -> Unit) 
         ) {
             Text(text = stringResource(R.string.start_new_session))
         }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = { throw RuntimeException("Test Crash") },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        ) {
+            Text(text = stringResource(R.string.test_crash))
+        }
     }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,4 +13,5 @@
     <string name="transcribing">Transcription…</string>
     <string name="transcription_failed">Échec de la transcription</string>
     <string name="transcription_label">Transcription : %1$s</string>
+    <string name="test_crash">Crash de test</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -13,4 +13,5 @@
     <string name="transcribing">Trascrizione…</string>
     <string name="transcription_failed">Trascrizione fallita</string>
     <string name="transcription_label">Trascrizione: %1$s</string>
+    <string name="test_crash">Crash di test</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="transcribing">Transcribing…</string>
     <string name="transcription_failed">Transcription failed</string>
     <string name="transcription_label">Transcription: %1$s</string>
+    <string name="test_crash">Test Crash</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a button to trigger a runtime crash from the story list screen
- provide localized string resources for the crash test button

## Testing
- `./gradlew test --console=plain` *(fails: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_68b20afc6f60832587577f225cf2f4fa