### PR TITLE
Log transcription failure in results to Crashlytics

### DIFF
--- a/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
@@ -202,7 +202,14 @@ private fun transcribeSegment(
     recognizer.setRecognitionListener(object : RecognitionListener {
         override fun onResults(results: Bundle?) {
             val text = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()
-            transcriptions[index] = text ?: context.getString(R.string.transcription_failed)
+            if (text != null) {
+                transcriptions[index] = text
+            } else {
+                FirebaseCrashlytics.getInstance().recordException(
+                    Exception("SpeechRecognizer returned null result")
+                )
+                transcriptions[index] = context.getString(R.string.transcription_failed)
+            }
             recognizer.destroy()
         }
 


### PR DESCRIPTION
## Summary
- report when the speech recognizer returns no transcription so Crashlytics captures the failure

## Testing
- `./gradlew test` *(fails: Starting a Gradle Daemon, 1 busy Daemon could not be reused, use --status for details)*

------
https://chatgpt.com/codex/tasks/task_e_68b20f9e50b48325abc2cf5ca686fd13