### PR TITLE
Fix Log import and manifest package

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.immagineran.no">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
+import android.util.Log
 import java.util.Locale
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts


### PR DESCRIPTION
## Summary
- add missing android.util.Log import to StoryCreationScreen
- remove deprecated package attribute from AndroidManifest

## Testing
- `./gradlew assembleRelease` *(fails: File google-services.json is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a5fde7488325bcc0b7e1b7c05c9d