### PR TITLE
Add configuration panel for choosing transcription method

### DIFF
--- a/app/src/main/java/com/immagineran/no/LocalTranscriber.kt
+++ b/app/src/main/java/com/immagineran/no/LocalTranscriber.kt
@@ -1,8 +1,17 @@
 package com.immagineran.no
 
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
 import android.util.Log
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import java.io.File
+import java.util.Locale
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
 /**
  * Simple wrapper around the on-device transcription engine.
@@ -11,17 +20,45 @@ import java.io.File
  * transcription issues can be debugged more easily in production.
  */
 class LocalTranscriber(
+    private val context: Context,
     private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance()
-) {
-    fun transcribe(file: File): String? {
-        return try {
-            // TODO: Invoke real local ASR engine
-            "" // Placeholder for the transcription result
-        } catch (e: Exception) {
-            crashlytics.log("Transcription failed for ${file.name}")
-            crashlytics.recordException(e)
-            Log.e("LocalTranscriber", "Transcription failed for ${file.name}", e)
-            null
+) : Transcriber {
+    override suspend fun transcribe(file: File): String? = suspendCancellableCoroutine { cont ->
+        val recognizer = SpeechRecognizer.createSpeechRecognizer(context)
+        recognizer.setRecognitionListener(object : RecognitionListener {
+            override fun onResults(results: Bundle?) {
+                val text =
+                    results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()
+                cont.resume(text)
+                recognizer.destroy()
+            }
+
+            override fun onError(error: Int) {
+                crashlytics.log("Transcription failed for ${file.name} with code $error")
+                crashlytics.recordException(Exception("SpeechRecognizer error code: $error"))
+                Log.e("LocalTranscriber", "Transcription failed for ${file.name}: $error")
+                cont.resume(null)
+                recognizer.destroy()
+            }
+
+            override fun onReadyForSpeech(params: Bundle?) {}
+            override fun onBeginningOfSpeech() {}
+            override fun onRmsChanged(rmsdB: Float) {}
+            override fun onBufferReceived(buffer: ByteArray?) {}
+            override fun onEndOfSpeech() {}
+            override fun onPartialResults(partialResults: Bundle?) {}
+            override fun onEvent(eventType: Int, params: Bundle?) {}
+        })
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            val locale: Locale = context.resources.configuration.locales[0]
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE, locale.toLanguageTag())
+            putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
+            putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+            putExtra(RecognizerIntent.EXTRA_AUDIO_SOURCE, file.absolutePath)
         }
+        recognizer.startListening(intent)
+        cont.invokeOnCancellation { recognizer.destroy() }
     }
 }
+

--- a/app/src/main/java/com/immagineran/no/SettingsManager.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsManager.kt
@@ -1,0 +1,25 @@
+package com.immagineran.no
+
+import android.content.Context
+
+private const val PREFS_NAME = "app_settings"
+private const val KEY_TRANSCRIPTION_METHOD = "transcription_method"
+
+/**
+ * Persists user-configurable settings.
+ */
+object SettingsManager {
+    fun getTranscriptionMethod(context: Context): TranscriptionMethod {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val name = prefs.getString(KEY_TRANSCRIPTION_METHOD, null)
+        return name?.let {
+            runCatching { TranscriptionMethod.valueOf(it) }.getOrNull()
+        } ?: TranscriptionMethod.LOCAL
+    }
+
+    fun setTranscriptionMethod(context: Context, method: TranscriptionMethod) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putString(KEY_TRANSCRIPTION_METHOD, method.name).apply()
+    }
+}
+

--- a/app/src/main/java/com/immagineran/no/SettingsScreen.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsScreen.kt
@@ -1,0 +1,51 @@
+package com.immagineran.no
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    var selected by remember { mutableStateOf(SettingsManager.getTranscriptionMethod(context)) }
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text(text = stringResource(R.string.settings_title), style = MaterialTheme.typography.h5)
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.transcription_method),
+            style = MaterialTheme.typography.h6
+        )
+        TranscriptionMethod.values().forEach { method ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            ) {
+                RadioButton(
+                    selected = method == selected,
+                    onClick = { selected = method }
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = stringResource(id = method.labelRes))
+            }
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Button(
+            onClick = {
+                SettingsManager.setTranscriptionMethod(context, selected)
+                onBack()
+            },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        ) {
+            Text(text = stringResource(R.string.save))
+        }
+    }
+}
+

--- a/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
@@ -3,14 +3,7 @@ package com.immagineran.no
 import android.Manifest
 import android.media.MediaPlayer
 import android.media.MediaRecorder
-import android.content.Intent
 import android.content.pm.PackageManager
-import android.os.Bundle
-import android.speech.RecognitionListener
-import android.speech.RecognizerIntent
-import android.speech.SpeechRecognizer
-import android.util.Log
-import java.util.Locale
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
@@ -25,25 +18,25 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.launch
 import java.io.File
-import com.google.firebase.crashlytics.FirebaseCrashlytics
-
-import com.immagineran.no.LocalTranscriber
 
 @Composable
 fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List<File>) -> Unit) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var isRecording by remember { mutableStateOf(false) }
     val segments = remember { mutableStateListOf<File>().apply { addAll(initialSegments) } }
     val transcriptions = remember { mutableStateListOf<String?>().apply { repeat(initialSegments.size) { add(null) } } }
     var currentIndex by remember { mutableStateOf(-1) }
     var recorder by remember { mutableStateOf<MediaRecorder?>(null) }
     var player by remember { mutableStateOf<MediaPlayer?>(null) }
-    val transcriber = remember { LocalTranscriber() }
+    val method = remember { SettingsManager.getTranscriptionMethod(context) }
+    val transcriber = remember { TranscriberFactory.create(context, method) }
 
     LaunchedEffect(Unit) {
         initialSegments.forEachIndexed { idx, file ->
-            transcribeSegment(context, file, idx, transcriptions)
+            transcribeSegment(context, file, idx, transcriptions, transcriber, scope)
         }
     }
 
@@ -66,12 +59,9 @@ fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Button(onClick = {
             if (isRecording) {
-                val file = segments[currentIndex]
                 stopRecording(recorder) { recorder = null }
-                transcribeSegment(context, segments[currentIndex], currentIndex, transcriptions)
+                transcribeSegment(context, segments[currentIndex], currentIndex, transcriptions, transcriber, scope)
                 isRecording = false
-                val transcript = transcriber.transcribe(file)
-                Log.d("StoryCreation", "Transcript for ${file.name}: ${transcript ?: "<null>"}")
                 currentIndex = -1
             } else {
                 val permission = Manifest.permission.RECORD_AUDIO
@@ -98,7 +88,7 @@ fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List
                 Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
                         Text(
                             text = stringResource(R.string.segment_number, index + 1),
@@ -131,7 +121,7 @@ fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List
                         } else {
                             stringResource(R.string.transcribing)
                         },
-                        modifier = Modifier.padding(start = 16.dp)
+                        modifier = Modifier.padding(start = 16.dp),
                     )
                 }
             }
@@ -139,10 +129,26 @@ fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List
 
         Button(
             onClick = { onDone(segments.toList()) },
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+            modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
             Text(stringResource(R.string.done))
         }
+    }
+}
+
+private fun transcribeSegment(
+    context: android.content.Context,
+    file: File,
+    index: Int,
+    transcriptions: MutableList<String?>,
+    transcriber: Transcriber,
+    scope: kotlinx.coroutines.CoroutineScope
+) {
+    transcriptions[index] = null
+    scope.launch {
+        val result = transcriber.transcribe(file)
+            ?: context.getString(R.string.transcription_failed)
+        transcriptions[index] = result
     }
 }
 
@@ -153,9 +159,9 @@ private fun startRecording(
     index: Int,
     onRecorder: (MediaRecorder) -> Unit,
     onStart: () -> Unit,
-    onIndex: (Int) -> Unit = {}
+    onIndex: (Int) -> Unit = {},
 ) {
-    val file = File(context.filesDir, "segment_${System.currentTimeMillis()}.m4a")
+    val file = File(context.filesDir, "segment_${'$'}{System.currentTimeMillis()}.m4a")
     val actualIndex = if (index >= 0 && index < segments.size) {
         segments[index].delete()
         segments[index] = file
@@ -196,53 +202,5 @@ private fun playSegment(file: File, currentPlayer: MediaPlayer?, onPlayer: (Medi
     mp.prepare()
     mp.start()
     onPlayer(mp)
-}
-
-private fun transcribeSegment(
-    context: android.content.Context,
-    file: File,
-    index: Int,
-    transcriptions: MutableList<String?>
-) {
-    transcriptions[index] = null
-    val recognizer = SpeechRecognizer.createSpeechRecognizer(context)
-    recognizer.setRecognitionListener(object : RecognitionListener {
-        override fun onResults(results: Bundle?) {
-            val text = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()
-            if (text != null) {
-                transcriptions[index] = text
-            } else {
-                FirebaseCrashlytics.getInstance().recordException(
-                    Exception("SpeechRecognizer returned null result")
-                )
-                transcriptions[index] = context.getString(R.string.transcription_failed)
-            }
-            recognizer.destroy()
-        }
-
-        override fun onError(error: Int) {
-            FirebaseCrashlytics.getInstance()
-                .recordException(Exception("SpeechRecognizer error code: $error"))
-            transcriptions[index] = context.getString(R.string.transcription_failed)
-            recognizer.destroy()
-        }
-
-        override fun onReadyForSpeech(params: Bundle?) {}
-        override fun onBeginningOfSpeech() {}
-        override fun onRmsChanged(rmsdB: Float) {}
-        override fun onBufferReceived(buffer: ByteArray?) {}
-        override fun onEndOfSpeech() {}
-        override fun onPartialResults(partialResults: Bundle?) {}
-        override fun onEvent(eventType: Int, params: Bundle?) {}
-    })
-    val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-        putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-        val locale: Locale = context.resources.configuration.locales[0]
-        putExtra(RecognizerIntent.EXTRA_LANGUAGE, locale.toLanguageTag())
-        putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, true)
-        putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
-        putExtra(RecognizerIntent.EXTRA_AUDIO_SOURCE, file.absolutePath)
-    }
-    recognizer.startListening(intent)
 }
 

--- a/app/src/main/java/com/immagineran/no/Transcriber.kt
+++ b/app/src/main/java/com/immagineran/no/Transcriber.kt
@@ -1,0 +1,14 @@
+package com.immagineran.no
+
+import java.io.File
+
+/**
+ * Abstraction for different transcription providers.
+ */
+interface Transcriber {
+    /**
+     * Transcribes the given audio file and returns the recognized text or null on failure.
+     */
+    suspend fun transcribe(file: File): String?
+}
+

--- a/app/src/main/java/com/immagineran/no/TranscriberFactory.kt
+++ b/app/src/main/java/com/immagineran/no/TranscriberFactory.kt
@@ -1,0 +1,13 @@
+package com.immagineran.no
+
+import android.content.Context
+
+/**
+ * Creates [Transcriber] instances based on the chosen [TranscriptionMethod].
+ */
+object TranscriberFactory {
+    fun create(context: Context, method: TranscriptionMethod): Transcriber = when (method) {
+        TranscriptionMethod.LOCAL -> LocalTranscriber(context)
+    }
+}
+

--- a/app/src/main/java/com/immagineran/no/TranscriptionMethod.kt
+++ b/app/src/main/java/com/immagineran/no/TranscriptionMethod.kt
@@ -1,0 +1,11 @@
+package com.immagineran.no
+
+import androidx.annotation.StringRes
+
+/**
+ * Available transcription backends.
+ */
+enum class TranscriptionMethod(@StringRes val labelRes: Int) {
+    LOCAL(R.string.transcription_method_local);
+}
+

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,4 +14,9 @@
     <string name="transcription_failed">Échec de la transcription</string>
     <string name="transcription_label">Transcription : %1$s</string>
     <string name="test_crash">Crash de test</string>
+    <string name="settings">Paramètres</string>
+    <string name="settings_title">Paramètres</string>
+    <string name="transcription_method">Méthode de transcription</string>
+    <string name="transcription_method_local">Service local</string>
+    <string name="save">Enregistrer</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -14,4 +14,9 @@
     <string name="transcription_failed">Trascrizione fallita</string>
     <string name="transcription_label">Trascrizione: %1$s</string>
     <string name="test_crash">Crash di test</string>
+    <string name="settings">Impostazioni</string>
+    <string name="settings_title">Impostazioni</string>
+    <string name="transcription_method">Metodo di trascrizione</string>
+    <string name="transcription_method_local">Servizio locale</string>
+    <string name="save">Salva</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,9 @@
     <string name="transcription_failed">Transcription failed</string>
     <string name="transcription_label">Transcription: %1$s</string>
     <string name="test_crash">Test Crash</string>
+    <string name="settings">Settings</string>
+    <string name="settings_title">Settings</string>
+    <string name="transcription_method">Transcription method</string>
+    <string name="transcription_method_local">Local service</string>
+    <string name="save">Save</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add settings screen allowing users to choose the transcription method
- Introduce transcriber abstraction and local implementation
- Wire settings into main UI and persist choice

## Testing
- `./gradlew test` *(fails: File google-services.json is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2adb99b988325b9f1e5e4338fcad5