### PR TITLE
Add Groq Whisper Turbo transcription option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,9 +15,11 @@ android {
         targetSdk 34
         versionCode 1
         versionName "0.1"
+        buildConfigField "String", "GROQ_API_KEY", "\"${System.getenv('GROQ_API_KEY') ?: ''}\""
     }
     buildFeatures {
         compose true
+        buildConfig true
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.5.0'
@@ -43,6 +45,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui:1.5.0'
     implementation 'androidx.compose.material:material:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation platform('com.google.firebase:firebase-bom:32.3.1')
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
     implementation 'com.google.firebase:firebase-analytics-ktx'

--- a/app/src/main/java/com/immagineran/no/GroqTranscriber.kt
+++ b/app/src/main/java/com/immagineran/no/GroqTranscriber.kt
@@ -1,0 +1,62 @@
+package com.immagineran.no
+
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * Transcriber implementation that uses Groq's Whisper Turbo model.
+ */
+class GroqTranscriber(
+    private val client: OkHttpClient = OkHttpClient(),
+    private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance(),
+) : Transcriber {
+    override suspend fun transcribe(file: File): String? = withContext(Dispatchers.IO) {
+        val key = BuildConfig.GROQ_API_KEY
+        if (key.isBlank()) {
+            Log.e("GroqTranscriber", "Missing Groq API key")
+            crashlytics.log("Groq API key missing")
+            return@withContext null
+        }
+
+        runCatching {
+            val body = MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart(
+                    "file",
+                    file.name,
+                    file.asRequestBody("audio/m4a".toMediaType())
+                )
+                .addFormDataPart("model", "whisper-large-v3-turbo")
+                .build()
+
+            val request = Request.Builder()
+                .url("https://api.groq.com/openai/v1/audio/transcriptions")
+                .header("Authorization", "Bearer $key")
+                .post(body)
+                .build()
+
+            client.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) {
+                    Log.e("GroqTranscriber", "HTTP ${'$'}{resp.code}")
+                    crashlytics.log("Groq transcription failed: ${'$'}{resp.code}")
+                    return@withContext null
+                }
+                val json = JSONObject(resp.body?.string() ?: return@withContext null)
+                json.optString("text", null)
+            }
+        }.getOrElse { e ->
+            Log.e("GroqTranscriber", "Transcription error", e)
+            crashlytics.recordException(e)
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/immagineran/no/TranscriberFactory.kt
+++ b/app/src/main/java/com/immagineran/no/TranscriberFactory.kt
@@ -8,6 +8,7 @@ import android.content.Context
 object TranscriberFactory {
     fun create(context: Context, method: TranscriptionMethod): Transcriber = when (method) {
         TranscriptionMethod.LOCAL -> LocalTranscriber(context)
+        TranscriptionMethod.GROQ -> GroqTranscriber()
     }
 }
 

--- a/app/src/main/java/com/immagineran/no/TranscriptionMethod.kt
+++ b/app/src/main/java/com/immagineran/no/TranscriptionMethod.kt
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes
  * Available transcription backends.
  */
 enum class TranscriptionMethod(@StringRes val labelRes: Int) {
-    LOCAL(R.string.transcription_method_local);
+    LOCAL(R.string.transcription_method_local),
+    GROQ(R.string.transcription_method_groq);
 }
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -18,5 +18,6 @@
     <string name="settings_title">Paramètres</string>
     <string name="transcription_method">Méthode de transcription</string>
     <string name="transcription_method_local">Service local</string>
+    <string name="transcription_method_groq">Groq Whisper Turbo</string>
     <string name="save">Enregistrer</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -18,5 +18,6 @@
     <string name="settings_title">Impostazioni</string>
     <string name="transcription_method">Metodo di trascrizione</string>
     <string name="transcription_method_local">Servizio locale</string>
+    <string name="transcription_method_groq">Groq Whisper Turbo</string>
     <string name="save">Salva</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,5 +23,6 @@
     <string name="settings_title">Settings</string>
     <string name="transcription_method">Transcription method</string>
     <string name="transcription_method_local">Local service</string>
+    <string name="transcription_method_groq">Groq Whisper Turbo</string>
     <string name="save">Save</string>
 </resources>


### PR DESCRIPTION
## Summary
- add Groq transcription backend using Whisper Turbo model
- expose API key via BuildConfig and OkHttp dependency
- allow selecting Groq in transcription settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b13ad2fc8325896e90bc99a83cfc