### PR TITLE
Refactor story stitching into processing pipeline

### DIFF
--- a/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
@@ -1,0 +1,39 @@
+package com.immagineran.no
+
+/**
+ * Container for data moving through the processing pipeline.
+ */
+data class ProcessingContext(
+    val prompt: String,
+    val segments: List<String>,
+    var story: String? = null,
+)
+
+/**
+ * A single step in a processing pipeline.
+ */
+fun interface ProcessingStep {
+    suspend fun process(context: ProcessingContext)
+}
+
+/**
+ * Simple pipeline executing a list of [ProcessingStep]s sequentially.
+ */
+class ProcessingPipeline(private val steps: List<ProcessingStep>) {
+    suspend fun run(context: ProcessingContext): ProcessingContext {
+        steps.forEach { it.process(context) }
+        return context
+    }
+}
+
+/**
+ * Step that stitches a list of transcribed segments into a story.
+ */
+class StoryStitchingStep(
+    private val stitcher: StoryStitcher = StoryStitcher(),
+) : ProcessingStep {
+    override suspend fun process(context: ProcessingContext) {
+        context.story = stitcher.stitch(context.prompt, context.segments)
+    }
+}
+

--- a/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryCreationScreen.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 
 @Composable
-fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List<File>, String) -> Unit) {
+fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List<File>, List<String?>) -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var isRecording by remember { mutableStateOf(false) }
@@ -33,7 +33,6 @@ fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List
     var player by remember { mutableStateOf<MediaPlayer?>(null) }
     val method = remember { SettingsManager.getTranscriptionMethod(context) }
     val transcriber = remember { TranscriberFactory.create(context, method) }
-    val stitcher = remember { StoryStitcher() }
 
     LaunchedEffect(Unit) {
         initialSegments.forEachIndexed { idx, file ->
@@ -129,17 +128,7 @@ fun StoryCreationScreen(initialSegments: List<File> = emptyList(), onDone: (List
         }
 
         Button(
-            onClick = {
-                if (transcriptions.all { it != null }) {
-                    scope.launch {
-                        val prompt = context.getString(R.string.story_prompt)
-                        val result = stitcher.stitch(prompt, transcriptions.filterNotNull()) ?: ""
-                        onDone(segments.toList(), result)
-                    }
-                } else {
-                    onDone(segments.toList(), "")
-                }
-            },
+            onClick = { onDone(segments.toList(), transcriptions.toList()) },
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
             Text(stringResource(R.string.done))


### PR DESCRIPTION
## Summary
- add a generic processing pipeline with a story stitching step
- delegate stitching out of StoryCreationScreen and trigger pipeline on session completion

## Testing
- `./gradlew test` *(fails: File google-services.json is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f2f545388325b2bf9783a3aad2b0