### PR TITLE
feat: extract story assets and generate templates

### DIFF
--- a/app/src/main/java/com/immagineran/no/ImageGenerator.kt
+++ b/app/src/main/java/com/immagineran/no/ImageGenerator.kt
@@ -1,0 +1,74 @@
+package com.immagineran.no
+
+import android.util.Base64
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+
+class ImageGenerator(
+    private val client: OkHttpClient = OkHttpClient(),
+    private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance(),
+) {
+    suspend fun generate(prompt: String, file: File): String? = withContext(Dispatchers.IO) {
+        val key = BuildConfig.OPENROUTER_API_KEY
+        if (key.isBlank()) {
+            Log.e("ImageGenerator", "Missing OpenRouter API key")
+            crashlytics.log("OpenRouter API key missing")
+            return@withContext null
+        }
+        runCatching {
+            val root = JSONObject().apply {
+                put("model", "google/gemini-2.5-flash-image-preview")
+                put("messages", JSONArray().apply {
+                    put(JSONObject().apply {
+                        put("role", "user")
+                        put("content", JSONArray().apply {
+                            put(JSONObject().apply {
+                                put("type", "text")
+                                put("text", prompt)
+                            })
+                        })
+                    })
+                })
+            }
+            val body = root.toString().toRequestBody("application/json".toMediaType())
+            val request = Request.Builder()
+                .url("https://openrouter.ai/api/v1/chat/completions")
+                .header("Authorization", "Bearer $key")
+                .header("Content-Type", "application/json")
+                .post(body)
+                .build()
+            client.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) {
+                    Log.e("ImageGenerator", "HTTP ${resp.code}")
+                    crashlytics.log("OpenRouter image failed: ${resp.code}")
+                    return@withContext null
+                }
+                val json = JSONObject(resp.body?.string() ?: return@withContext null)
+                val choices = json.optJSONArray("choices") ?: return@withContext null
+                if (choices.length() == 0) return@withContext null
+                val message = choices.getJSONObject(0).optJSONObject("message") ?: return@withContext null
+                val content = message.optJSONArray("content") ?: return@withContext null
+                if (content.length() == 0) return@withContext null
+                val imgObj = content.getJSONObject(0)
+                val b64 = imgObj.optString("image_base64")
+                if (b64.isBlank()) return@withContext null
+                val bytes = Base64.decode(b64, Base64.DEFAULT)
+                file.outputStream().use { it.write(bytes) }
+                file.absolutePath
+            }
+        }.getOrElse { e ->
+            Log.e("ImageGenerator", "Generation error", e)
+            crashlytics.recordException(e)
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/immagineran/no/Story.kt
+++ b/app/src/main/java/com/immagineran/no/Story.kt
@@ -1,9 +1,23 @@
 package com.immagineran.no
 
+data class CharacterAsset(
+    val name: String,
+    val description: String,
+    val image: String? = null,
+)
+
+data class EnvironmentAsset(
+    val name: String,
+    val description: String,
+    val image: String? = null,
+)
+
 data class Story(
     val id: Long,
     val title: String,
     val content: String,
     val segments: List<String> = emptyList(),
-    val processed: Boolean = false
+    val processed: Boolean = false,
+    val characters: List<CharacterAsset> = emptyList(),
+    val environments: List<EnvironmentAsset> = emptyList(),
 )

--- a/app/src/main/java/com/immagineran/no/StoryAssetExtractor.kt
+++ b/app/src/main/java/com/immagineran/no/StoryAssetExtractor.kt
@@ -1,0 +1,92 @@
+package com.immagineran.no
+
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+class StoryAssetExtractor(
+    private val client: OkHttpClient = OkHttpClient(),
+    private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance(),
+) {
+    private suspend fun callLLM(prompt: String): JSONArray? = withContext(Dispatchers.IO) {
+        val key = BuildConfig.OPENROUTER_API_KEY
+        if (key.isBlank()) {
+            Log.e("StoryAssetExtractor", "Missing OpenRouter API key")
+            crashlytics.log("OpenRouter API key missing")
+            return@withContext null
+        }
+        runCatching {
+            val root = JSONObject().apply {
+                put("model", "mistralai/mistral-nemo")
+                put("messages", JSONArray().apply {
+                    put(JSONObject().apply {
+                        put("role", "user")
+                        put("content", prompt)
+                    })
+                })
+            }
+            val body = root.toString().toRequestBody("application/json".toMediaType())
+            val request = Request.Builder()
+                .url("https://openrouter.ai/api/v1/chat/completions")
+                .header("Authorization", "Bearer $key")
+                .header("Content-Type", "application/json")
+                .post(body)
+                .build()
+            client.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) {
+                    Log.e("StoryAssetExtractor", "HTTP ${resp.code}")
+                    crashlytics.log("OpenRouter extract failed: ${resp.code}")
+                    return@withContext null
+                }
+                val json = JSONObject(resp.body?.string() ?: return@withContext null)
+                val choices = json.optJSONArray("choices") ?: return@withContext null
+                if (choices.length() == 0) return@withContext null
+                val content = choices.getJSONObject(0)
+                    .optJSONObject("message")
+                    ?.optString("content") ?: return@withContext null
+                JSONArray(content)
+            }
+        }.getOrElse { e ->
+            Log.e("StoryAssetExtractor", "LLM error", e)
+            crashlytics.recordException(e)
+            null
+        }
+    }
+
+    suspend fun extractCharacters(story: String): List<CharacterAsset> {
+        val prompt = "Extract the characters from the following story. For each character provide a short graphic description. Reply in JSON array of objects with keys 'name' and 'description'. Story:\n$story"
+        val arr = callLLM(prompt) ?: return emptyList()
+        val result = mutableListOf<CharacterAsset>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            val name = obj.optString("name")
+            val desc = obj.optString("description")
+            if (name.isNotBlank() && desc.isNotBlank()) {
+                result.add(CharacterAsset(name, desc))
+            }
+        }
+        return result
+    }
+
+    suspend fun extractEnvironments(story: String): List<EnvironmentAsset> {
+        val prompt = "Extract the environments from the following story. For each environment provide a short graphic description. Reply in JSON array of objects with keys 'name' and 'description'. Story:\n$story"
+        val arr = callLLM(prompt) ?: return emptyList()
+        val result = mutableListOf<EnvironmentAsset>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            val name = obj.optString("name")
+            val desc = obj.optString("description")
+            if (name.isNotBlank() && desc.isNotBlank()) {
+                result.add(EnvironmentAsset(name, desc))
+            }
+        }
+        return result
+    }
+}

--- a/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
@@ -1,0 +1,58 @@
+package com.immagineran.no
+
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun StoryDetailScreen(story: Story, onBack: () -> Unit) {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Button(onClick = onBack) { Text(stringResource(R.string.back)) }
+        Text(story.title, style = MaterialTheme.typography.h5, modifier = Modifier.padding(top = 8.dp))
+        if (story.content.isNotBlank()) {
+            Text(story.content, modifier = Modifier.padding(vertical = 8.dp))
+        }
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            item { Text(stringResource(R.string.characters_title), style = MaterialTheme.typography.h6) }
+            items(story.characters) { c ->
+                Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                    c.image?.let {
+                        val bmp = BitmapFactory.decodeFile(it)
+                        if (bmp != null) {
+                            Image(bitmap = bmp.asImageBitmap(), contentDescription = c.name, modifier = Modifier.size(64.dp))
+                        }
+                    }
+                    Column(modifier = Modifier.padding(start = 8.dp)) {
+                        Text(c.name, style = MaterialTheme.typography.subtitle1)
+                        Text(c.description)
+                    }
+                }
+            }
+            item { Text(stringResource(R.string.environments_title), style = MaterialTheme.typography.h6, modifier = Modifier.padding(top = 8.dp)) }
+            items(story.environments) { e ->
+                Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                    e.image?.let {
+                        val bmp = BitmapFactory.decodeFile(it)
+                        if (bmp != null) {
+                            Image(bitmap = bmp.asImageBitmap(), contentDescription = e.name, modifier = Modifier.size(64.dp))
+                        }
+                    }
+                    Column(modifier = Modifier.padding(start = 8.dp)) {
+                        Text(e.name, style = MaterialTheme.typography.subtitle1)
+                        Text(e.description)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/immagineran/no/StoryRepository.kt
+++ b/app/src/main/java/com/immagineran/no/StoryRepository.kt
@@ -23,13 +23,43 @@ object StoryRepository {
                     segments.add(segmentsArray.getString(j))
                 }
             }
+            val characters = mutableListOf<CharacterAsset>()
+            val charArray = obj.optJSONArray("characters")
+            if (charArray != null) {
+                for (j in 0 until charArray.length()) {
+                    val cObj = charArray.optJSONObject(j) ?: continue
+                    characters.add(
+                        CharacterAsset(
+                            name = cObj.optString("name"),
+                            description = cObj.optString("description"),
+                            image = cObj.optString("image", null)
+                        )
+                    )
+                }
+            }
+            val environments = mutableListOf<EnvironmentAsset>()
+            val envArray = obj.optJSONArray("environments")
+            if (envArray != null) {
+                for (j in 0 until envArray.length()) {
+                    val eObj = envArray.optJSONObject(j) ?: continue
+                    environments.add(
+                        EnvironmentAsset(
+                            name = eObj.optString("name"),
+                            description = eObj.optString("description"),
+                            image = eObj.optString("image", null)
+                        )
+                    )
+                }
+            }
             result.add(
                 Story(
                     id = obj.getLong("id"),
                     title = obj.getString("title"),
                     content = obj.optString("content", ""),
                     segments = segments,
-                    processed = obj.optBoolean("processed", false)
+                    processed = obj.optBoolean("processed", false),
+                    characters = characters,
+                    environments = environments,
                 )
             )
         }
@@ -83,6 +113,24 @@ object StoryRepository {
             val segmentsArray = JSONArray()
             s.segments.forEach { segmentsArray.put(it) }
             obj.put("segments", segmentsArray)
+            val charArray = JSONArray()
+            s.characters.forEach { c ->
+                val cObj = JSONObject()
+                cObj.put("name", c.name)
+                cObj.put("description", c.description)
+                c.image?.let { cObj.put("image", it) }
+                charArray.put(cObj)
+            }
+            obj.put("characters", charArray)
+            val envArray = JSONArray()
+            s.environments.forEach { e ->
+                val eObj = JSONObject()
+                eObj.put("name", e.name)
+                eObj.put("description", e.description)
+                e.image?.let { eObj.put("image", it) }
+                envArray.put(eObj)
+            }
+            obj.put("environments", envArray)
             array.put(obj)
         }
         val file = File(context.filesDir, FILE_NAME)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -21,4 +21,8 @@
     <string name="transcription_method_groq">Groq Whisper Turbo</string>
     <string name="save">Enregistrer</string>
     <string name="story_prompt">Veuillez assembler ces segments en un court storyboard :</string>
+    <string name="view">Voir</string>
+    <string name="back">Retour</string>
+    <string name="characters_title">Personnages</string>
+    <string name="environments_title">Environnements</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -21,4 +21,8 @@
     <string name="transcription_method_groq">Groq Whisper Turbo</string>
     <string name="save">Salva</string>
     <string name="story_prompt">Per favore unisci questi segmenti in uno storyboard breve:</string>
+    <string name="view">Vedi</string>
+    <string name="back">Indietro</string>
+    <string name="characters_title">Personaggi</string>
+    <string name="environments_title">Ambientazioni</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,8 @@
     <string name="transcription_method_groq">Groq Whisper Turbo</string>
     <string name="save">Save</string>
     <string name="story_prompt">Please stitch these segments into a short storyboard:</string>
+    <string name="view">View</string>
+    <string name="back">Back</string>
+    <string name="characters_title">Characters</string>
+    <string name="environments_title">Environments</string>
 </resources>


### PR DESCRIPTION
## Summary
- extend processing pipeline to extract characters and environments and generate template images
- store assets with stories and add detail page to view them

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f8556ec483258682589617055358