### PR TITLE
feat: improve image generation prompts and UI

### DIFF
--- a/app/src/main/java/com/immagineran/no/ImageGenerator.kt
+++ b/app/src/main/java/com/immagineran/no/ImageGenerator.kt
@@ -17,7 +17,11 @@ class ImageGenerator(
     private val client: OkHttpClient = OkHttpClient(),
     private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance(),
 ) {
-    suspend fun generate(prompt: String, file: File): String? = withContext(Dispatchers.IO) {
+    /**
+     * Generates an image based on the given [description] and [style].
+     * Retries up to five times if the response does not contain an image.
+     */
+    suspend fun generate(description: String, style: ImageStyle, file: File): String? = withContext(Dispatchers.IO) {
         val key = BuildConfig.OPENROUTER_API_KEY
         if (key.isBlank()) {
             Log.e("ImageGenerator", "Missing OpenRouter API key")
@@ -25,50 +29,58 @@ class ImageGenerator(
             return@withContext null
         }
         runCatching {
-            val root = JSONObject().apply {
-                put("model", "google/gemini-2.5-flash-image-preview")
-                put("messages", JSONArray().apply {
-                    put(JSONObject().apply {
-                        put("role", "user")
-                        put("content", JSONArray().apply {
-                            put(JSONObject().apply {
-                                put("type", "text")
-                                put("text", prompt)
-                            })
-                        })
-                    })
-                })
+            val messages = JSONArray().apply {
+                put(message("Generate a ${style.prompt} character sheet from the following description: ${description}"))
             }
-            val body = root.toString().toRequestBody("application/json".toMediaType())
-            val request = Request.Builder()
-                .url("https://openrouter.ai/api/v1/chat/completions")
-                .header("Authorization", "Bearer $key")
-                .header("Content-Type", "application/json")
-                .post(body)
-                .build()
-            client.newCall(request).execute().use { resp ->
-                if (!resp.isSuccessful) {
-                    Log.e("ImageGenerator", "HTTP ${resp.code}")
-                    crashlytics.log("OpenRouter image failed: ${resp.code}")
-                    return@withContext null
+            repeat(5) { attempt ->
+                val root = JSONObject().apply {
+                    put("model", "google/gemini-2.5-flash-image-preview")
+                    put("messages", messages)
                 }
-                val json = JSONObject(resp.body?.string() ?: return@withContext null)
-                val choices = json.optJSONArray("choices") ?: return@withContext null
-                if (choices.length() == 0) return@withContext null
-                val message = choices.getJSONObject(0).optJSONObject("message") ?: return@withContext null
-                val content = message.optJSONArray("content") ?: return@withContext null
-                if (content.length() == 0) return@withContext null
-                val imgObj = content.getJSONObject(0)
-                val b64 = imgObj.optString("image_base64")
-                if (b64.isBlank()) return@withContext null
-                val bytes = Base64.decode(b64, Base64.DEFAULT)
-                file.outputStream().use { it.write(bytes) }
-                file.absolutePath
+                val body = root.toString().toRequestBody("application/json".toMediaType())
+                val request = Request.Builder()
+                    .url("https://openrouter.ai/api/v1/chat/completions")
+                    .header("Authorization", "Bearer $key")
+                    .header("Content-Type", "application/json")
+                    .post(body)
+                    .build()
+                client.newCall(request).execute().use { resp ->
+                    if (!resp.isSuccessful) {
+                        Log.e("ImageGenerator", "HTTP ${'$'}{resp.code}")
+                        crashlytics.log("OpenRouter image failed: ${'$'}{resp.code}")
+                        return@withContext null
+                    }
+                    val json = JSONObject(resp.body?.string() ?: return@withContext null)
+                    val choices = json.optJSONArray("choices") ?: return@withContext null
+                    if (choices.length() == 0) return@withContext null
+                    val message = choices.getJSONObject(0).optJSONObject("message") ?: return@withContext null
+                    val content = message.optJSONArray("content") ?: return@withContext null
+                    if (content.length() == 0) return@withContext null
+                    val imgObj = content.getJSONObject(0)
+                    val b64 = imgObj.optString("image_base64")
+                    if (b64.isNotBlank()) {
+                        val bytes = Base64.decode(b64, Base64.DEFAULT)
+                        file.outputStream().use { it.write(bytes) }
+                        return@withContext file.absolutePath
+                    }
+                }
+                messages.put(message("you did not generate any image, retry"))
             }
+            null
         }.getOrElse { e ->
             Log.e("ImageGenerator", "Generation error", e)
             crashlytics.recordException(e)
             null
         }
+    }
+
+    private fun message(text: String): JSONObject = JSONObject().apply {
+        put("role", "user")
+        put("content", JSONArray().apply {
+            put(JSONObject().apply {
+                put("type", "text")
+                put("text", text)
+            })
+        })
     }
 }

--- a/app/src/main/java/com/immagineran/no/ImageStyle.kt
+++ b/app/src/main/java/com/immagineran/no/ImageStyle.kt
@@ -1,0 +1,15 @@
+package com.immagineran.no
+
+import androidx.annotation.StringRes
+
+/**
+ * Supported visual styles for image generation.
+ *
+ * @property labelRes String resource for the user-facing label.
+ * @property prompt Token describing the style for the generator prompt.
+ */
+enum class ImageStyle(@StringRes val labelRes: Int, val prompt: String) {
+    PHOTOREALISTIC(R.string.style_photorealistic, "photorealistic"),
+    CARTOON(R.string.style_cartoon, "cartoon"),
+    MANGA(R.string.style_manga, "manga")
+}

--- a/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
@@ -67,14 +67,15 @@ class ImageGenerationStep(
 ) : ProcessingStep {
     override suspend fun process(context: ProcessingContext) {
         val dir = File(appContext.filesDir, context.id.toString()).apply { mkdirs() }
+        val style = SettingsManager.getImageStyle(appContext)
         context.characters = context.characters.mapIndexed { idx, asset ->
             val file = File(dir, "character_${'$'}idx.png")
-            val path = generator.generate(asset.description, file)
+            val path = generator.generate(asset.description, style, file)
             asset.copy(image = path)
         }
         context.environments = context.environments.mapIndexed { idx, asset ->
             val file = File(dir, "environment_${'$'}idx.png")
-            val path = generator.generate(asset.description, file)
+            val path = generator.generate(asset.description, style, file)
             asset.copy(image = path)
         }
     }

--- a/app/src/main/java/com/immagineran/no/SettingsManager.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 
 private const val PREFS_NAME = "app_settings"
 private const val KEY_TRANSCRIPTION_METHOD = "transcription_method"
+private const val KEY_IMAGE_STYLE = "image_style"
 
 /**
  * Persists user-configurable settings.
@@ -20,6 +21,23 @@ object SettingsManager {
     fun setTranscriptionMethod(context: Context, method: TranscriptionMethod) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         prefs.edit().putString(KEY_TRANSCRIPTION_METHOD, method.name).apply()
+    }
+
+    /**
+     * Retrieves the preferred [ImageStyle].
+     */
+    fun getImageStyle(context: Context): ImageStyle {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val name = prefs.getString(KEY_IMAGE_STYLE, ImageStyle.PHOTOREALISTIC.name)
+        return runCatching { ImageStyle.valueOf(name!!) }.getOrDefault(ImageStyle.PHOTOREALISTIC)
+    }
+
+    /**
+     * Persists the preferred [ImageStyle].
+     */
+    fun setImageStyle(context: Context, style: ImageStyle) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putString(KEY_IMAGE_STYLE, style.name).apply()
     }
 }
 

--- a/app/src/main/java/com/immagineran/no/SettingsScreen.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsScreen.kt
@@ -15,37 +15,56 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun SettingsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
-    var selected by remember { mutableStateOf(SettingsManager.getTranscriptionMethod(context)) }
+    var selectedTranscription by remember { mutableStateOf(SettingsManager.getTranscriptionMethod(context)) }
+    var selectedStyle by remember { mutableStateOf(SettingsManager.getImageStyle(context)) }
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text(text = stringResource(R.string.settings_title), style = MaterialTheme.typography.h5)
         Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = stringResource(R.string.transcription_method),
-            style = MaterialTheme.typography.h6
+            style = MaterialTheme.typography.h6,
         )
         TranscriptionMethod.values().forEach { method ->
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
             ) {
                 RadioButton(
-                    selected = method == selected,
-                    onClick = { selected = method }
+                    selected = method == selectedTranscription,
+                    onClick = { selectedTranscription = method },
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(text = stringResource(id = method.labelRes))
             }
         }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.image_style),
+            style = MaterialTheme.typography.h6,
+        )
+        ImageStyle.values().forEach { style ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+            ) {
+                RadioButton(
+                    selected = style == selectedStyle,
+                    onClick = { selectedStyle = style },
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = stringResource(id = style.labelRes))
+            }
+        }
         Spacer(modifier = Modifier.weight(1f))
         Button(
             onClick = {
-                SettingsManager.setTranscriptionMethod(context, selected)
+                SettingsManager.setTranscriptionMethod(context, selectedTranscription)
+                SettingsManager.setImageStyle(context, selectedStyle)
                 onBack()
             },
-            modifier = Modifier.align(Alignment.CenterHorizontally)
+            modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
             Text(text = stringResource(R.string.save))
         }
     }
 }
-

--- a/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
@@ -35,6 +35,9 @@ fun StoryDetailScreen(story: Story, onBack: () -> Unit) {
                     Column(modifier = Modifier.padding(start = 8.dp)) {
                         Text(c.name, style = MaterialTheme.typography.subtitle1)
                         Text(c.description)
+                        if (c.image == null) {
+                            Text(stringResource(R.string.image_generation_error))
+                        }
                     }
                 }
             }
@@ -50,6 +53,9 @@ fun StoryDetailScreen(story: Story, onBack: () -> Unit) {
                     Column(modifier = Modifier.padding(start = 8.dp)) {
                         Text(e.name, style = MaterialTheme.typography.subtitle1)
                         Text(e.description)
+                        if (e.image == null) {
+                            Text(stringResource(R.string.image_generation_error))
+                        }
                     }
                 }
             }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,6 +10,11 @@
     <string name="re_record">Réenregistrer</string>
     <string name="done">Terminer</string>
     <string name="segment_number">Segment %1$d</string>
+    <string name="unprocessed_stories_title">Sessions enregistrées</string>
+    <string name="processed_stories_title">Histoires terminées</string>
+    <string name="resume">Reprendre</string>
+    <string name="no_unprocessed_stories">Aucune session enregistrée</string>
+    <string name="delete">Supprimer</string>
     <string name="transcribing">Transcription…</string>
     <string name="transcription_failed">Échec de la transcription</string>
     <string name="transcription_label">Transcription : %1$s</string>
@@ -25,4 +30,9 @@
     <string name="back">Retour</string>
     <string name="characters_title">Personnages</string>
     <string name="environments_title">Environnements</string>
+    <string name="image_style">Style d\'image</string>
+    <string name="style_photorealistic">Photorealiste</string>
+    <string name="style_cartoon">Cartoon</string>
+    <string name="style_manga">Manga</string>
+    <string name="image_generation_error">Échec de la génération de l\'image</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -10,6 +10,11 @@
     <string name="re_record">Riregistra</string>
     <string name="done">Fatto</string>
     <string name="segment_number">Segmento %1$d</string>
+    <string name="unprocessed_stories_title">Sessioni registrate</string>
+    <string name="processed_stories_title">Storie finite</string>
+    <string name="resume">Riprendi</string>
+    <string name="no_unprocessed_stories">Nessuna sessione registrata</string>
+    <string name="delete">Elimina</string>
     <string name="transcribing">Trascrizione…</string>
     <string name="transcription_failed">Trascrizione fallita</string>
     <string name="transcription_label">Trascrizione: %1$s</string>
@@ -25,4 +30,9 @@
     <string name="back">Indietro</string>
     <string name="characters_title">Personaggi</string>
     <string name="environments_title">Ambientazioni</string>
+    <string name="image_style">Stile immagine</string>
+    <string name="style_photorealistic">Fotorealistico</string>
+    <string name="style_cartoon">Cartoon</string>
+    <string name="style_manga">Manga</string>
+    <string name="image_generation_error">Generazione dell\'immagine fallita</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,9 @@
     <string name="back">Back</string>
     <string name="characters_title">Characters</string>
     <string name="environments_title">Environments</string>
+    <string name="image_style">Image style</string>
+    <string name="style_photorealistic">Photorealistic</string>
+    <string name="style_cartoon">Cartoon</string>
+    <string name="style_manga">Manga</string>
+    <string name="image_generation_error">Image generation failed</string>
 </resources>


### PR DESCRIPTION
## Summary
- add configurable image style and persist in settings
- enhance image generation prompt with retries and error handling
- show image generation errors alongside descriptions

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b30892cbe883259f0cb5ff9cd486c0