### PR TITLE
Fix image overwriting during generation

### DIFF
--- a/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
@@ -69,12 +69,12 @@ class ImageGenerationStep(
         val dir = File(appContext.filesDir, context.id.toString()).apply { mkdirs() }
         val style = SettingsManager.getImageStyle(appContext)
         context.characters = context.characters.mapIndexed { idx, asset ->
-            val file = File(dir, "character_${'$'}idx.png")
+            val file = File(dir, "character_${idx}.png")
             val path = generator.generate(asset.description, style, file)
             asset.copy(image = path)
         }
         context.environments = context.environments.mapIndexed { idx, asset ->
-            val file = File(dir, "environment_${'$'}idx.png")
+            val file = File(dir, "environment_${idx}.png")
             val path = generator.generate(asset.description, style, file)
             asset.copy(image = path)
         }


### PR DESCRIPTION
## Summary
- Ensure unique filenames for generated character and environment images to prevent overwriting

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b31f78d2fc8325940bf402c3455316