### PR TITLE
Add scene composition and image generation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ local.properties
 # Misc
 .DS_Store
 android-commandlinetools.zip
+app/google-services.json

--- a/app/src/main/java/com/immagineran/no/MainActivity.kt
+++ b/app/src/main/java/com/immagineran/no/MainActivity.kt
@@ -48,7 +48,9 @@ class MainActivity : ComponentActivity() {
                                 StoryStitchingStep(),
                                 CharacterExtractionStep(),
                                 EnvironmentExtractionStep(),
-                                ImageGenerationStep(this@MainActivity)
+                                SceneCompositionStep(),
+                                ImageGenerationStep(this@MainActivity),
+                                SceneImageGenerationStep(this@MainActivity)
                             )
                         )
                     }
@@ -90,6 +92,7 @@ class MainActivity : ComponentActivity() {
                                                     processed = processed,
                                                     characters = procContext?.characters ?: emptyList(),
                                                     environments = procContext?.environments ?: emptyList(),
+                                                    scenes = procContext?.scenes ?: emptyList(),
                                                 )
                                                 StoryRepository.updateStory(context, updated)
                                                 storyToResume = null
@@ -106,6 +109,7 @@ class MainActivity : ComponentActivity() {
                                                     processed = processed,
                                                     characters = procContext?.characters ?: emptyList(),
                                                     environments = procContext?.environments ?: emptyList(),
+                                                    scenes = procContext?.scenes ?: emptyList(),
                                                 )
                                                 StoryRepository.addStory(context, story)
                                             }

--- a/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
@@ -13,6 +13,7 @@ data class ProcessingContext(
     var story: String? = null,
     var characters: List<CharacterAsset> = emptyList(),
     var environments: List<EnvironmentAsset> = emptyList(),
+    var scenes: List<Scene> = emptyList(),
 )
 
 /**

--- a/app/src/main/java/com/immagineran/no/SceneBuilder.kt
+++ b/app/src/main/java/com/immagineran/no/SceneBuilder.kt
@@ -1,0 +1,107 @@
+package com.immagineran.no
+
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+
+class SceneBuilder(
+    private val client: OkHttpClient = OkHttpClient(),
+    private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance(),
+) {
+    private suspend fun callLLM(prompt: String): JSONArray? = withContext(Dispatchers.IO) {
+        val key = BuildConfig.OPENROUTER_API_KEY
+        if (key.isBlank()) {
+            Log.e("SceneBuilder", "Missing OpenRouter API key")
+            crashlytics.log("OpenRouter API key missing")
+            return@withContext null
+        }
+        runCatching {
+            val root = JSONObject().apply {
+                put("model", "mistralai/mistral-nemo")
+                put("messages", JSONArray().apply {
+                    put(JSONObject().apply {
+                        put("role", "user")
+                        put("content", prompt)
+                    })
+                })
+            }
+            val body = root.toString().toRequestBody("application/json".toMediaType())
+            val request = Request.Builder()
+                .url("https://openrouter.ai/api/v1/chat/completions")
+                .header("Authorization", "Bearer $key")
+                .header("Content-Type", "application/json")
+                .post(body)
+                .build()
+            client.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) {
+                    Log.e("SceneBuilder", "HTTP ${'$'}{resp.code}")
+                    crashlytics.log("OpenRouter scene failed: ${'$'}{resp.code}")
+                    return@withContext null
+                }
+                val json = JSONObject(resp.body?.string() ?: return@withContext null)
+                val choices = json.optJSONArray("choices") ?: return@withContext null
+                if (choices.length() == 0) return@withContext null
+                val content = choices.getJSONObject(0)
+                    .optJSONObject("message")
+                    ?.optString("content") ?: return@withContext null
+                JSONArray(content)
+            }
+        }.getOrElse { e ->
+            Log.e("SceneBuilder", "LLM error", e)
+            crashlytics.recordException(e)
+            null
+        }
+    }
+
+    suspend fun buildScenes(
+        story: String,
+        characters: List<CharacterAsset>,
+        environments: List<EnvironmentAsset>,
+    ): List<Scene> {
+        val charList = characters.joinToString { "${'$'}{it.name}: ${'$'}{it.description}" }
+        val envList = environments.joinToString { "${'$'}{it.name}: ${'$'}{it.description}" }
+        val prompt = """
+            Given the following story, characters, and environments, split the story into scenes.
+            For each scene provide the narrative text, the environment name, and the list of character names present.
+            Reply in a JSON array where each item has keys 'text', 'environment', and 'characters'.
+            Story:
+            ${'$'}story
+            Characters: ${'$'}charList
+            Environments: ${'$'}envList
+        """.trimIndent()
+        val arr = callLLM(prompt) ?: return emptyList()
+        val scenes = mutableListOf<Scene>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            val text = obj.optString("text")
+            val envName = obj.optString("environment")
+            val env = environments.find { it.name.equals(envName, ignoreCase = true) }
+            val charNames = obj.optJSONArray("characters")
+            val chars = mutableListOf<CharacterAsset>()
+            if (charNames != null) {
+                for (j in 0 until charNames.length()) {
+                    val name = charNames.optString(j)
+                    characters.find { it.name.equals(name, ignoreCase = true) }?.let { chars.add(it) }
+                }
+            }
+            if (text.isNotBlank()) {
+                scenes.add(
+                    Scene(
+                        text = text,
+                        environment = env,
+                        characters = chars,
+                    )
+                )
+            }
+        }
+        return scenes
+    }
+}
+

--- a/app/src/main/java/com/immagineran/no/SceneSteps.kt
+++ b/app/src/main/java/com/immagineran/no/SceneSteps.kt
@@ -1,0 +1,37 @@
+package com.immagineran.no
+
+import android.content.Context
+import java.io.File
+
+class SceneCompositionStep(
+    private val builder: SceneBuilder = SceneBuilder(),
+) : ProcessingStep {
+    override suspend fun process(context: ProcessingContext) {
+        val story = context.story ?: return
+        context.scenes = builder.buildScenes(story, context.characters, context.environments)
+    }
+}
+
+class SceneImageGenerationStep(
+    private val appContext: Context,
+    private val generator: ImageGenerator = ImageGenerator(),
+) : ProcessingStep {
+    override suspend fun process(context: ProcessingContext) {
+        val dir = File(appContext.filesDir, context.id.toString()).apply { mkdirs() }
+        val style = SettingsManager.getImageStyle(appContext)
+        context.scenes = context.scenes.mapIndexed { idx, scene ->
+            val file = File(dir, "scene_${idx}.png")
+            val description = buildString {
+                append(scene.text)
+                scene.environment?.let { append(" Environment: ${it.description}.") }
+                if (scene.characters.isNotEmpty()) {
+                    append(" Characters: ")
+                    append(scene.characters.joinToString { it.description })
+                }
+            }
+            val path = generator.generate(description, style, file)
+            scene.copy(image = path)
+        }
+    }
+}
+

--- a/app/src/main/java/com/immagineran/no/Story.kt
+++ b/app/src/main/java/com/immagineran/no/Story.kt
@@ -12,6 +12,13 @@ data class EnvironmentAsset(
     val image: String? = null,
 )
 
+data class Scene(
+    val text: String,
+    val environment: EnvironmentAsset? = null,
+    val characters: List<CharacterAsset> = emptyList(),
+    val image: String? = null,
+)
+
 data class Story(
     val id: Long,
     val title: String,
@@ -20,4 +27,5 @@ data class Story(
     val processed: Boolean = false,
     val characters: List<CharacterAsset> = emptyList(),
     val environments: List<EnvironmentAsset> = emptyList(),
+    val scenes: List<Scene> = emptyList(),
 )

--- a/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
@@ -23,6 +23,24 @@ fun StoryDetailScreen(story: Story, onBack: () -> Unit) {
             Text(story.content, modifier = Modifier.padding(vertical = 8.dp))
         }
         LazyColumn(modifier = Modifier.weight(1f)) {
+            if (story.scenes.isNotEmpty()) {
+                item { Text(stringResource(R.string.scenes_title), style = MaterialTheme.typography.h6) }
+                items(story.scenes) { s ->
+                    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                        s.image?.let {
+                            val bmp = BitmapFactory.decodeFile(it)
+                            if (bmp != null) {
+                                Image(bitmap = bmp.asImageBitmap(), contentDescription = null, modifier = Modifier.height(128.dp).fillMaxWidth())
+                            }
+                        }
+                        Text(s.text, modifier = Modifier.padding(top = 4.dp))
+                        if (s.image == null) {
+                            Text(stringResource(R.string.image_generation_error))
+                        }
+                    }
+                }
+                item { Spacer(modifier = Modifier.height(8.dp)) }
+            }
             item { Text(stringResource(R.string.characters_title), style = MaterialTheme.typography.h6) }
             items(story.characters) { c ->
                 Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {

--- a/app/src/main/java/com/immagineran/no/StoryRepository.kt
+++ b/app/src/main/java/com/immagineran/no/StoryRepository.kt
@@ -51,6 +51,32 @@ object StoryRepository {
                     )
                 }
             }
+            val scenes = mutableListOf<Scene>()
+            val sceneArray = obj.optJSONArray("scenes")
+            if (sceneArray != null) {
+                for (j in 0 until sceneArray.length()) {
+                    val sObj = sceneArray.optJSONObject(j) ?: continue
+                    val text = sObj.optString("text")
+                    val envName = sObj.optString("environment")
+                    val env = environments.find { it.name == envName }
+                    val chars = mutableListOf<CharacterAsset>()
+                    val names = sObj.optJSONArray("characters")
+                    if (names != null) {
+                        for (k in 0 until names.length()) {
+                            val n = names.optString(k)
+                            characters.find { it.name == n }?.let { chars.add(it) }
+                        }
+                    }
+                    scenes.add(
+                        Scene(
+                            text = text,
+                            environment = env,
+                            characters = chars,
+                            image = sObj.optString("image", null)
+                        )
+                    )
+                }
+            }
             result.add(
                 Story(
                     id = obj.getLong("id"),
@@ -60,6 +86,7 @@ object StoryRepository {
                     processed = obj.optBoolean("processed", false),
                     characters = characters,
                     environments = environments,
+                    scenes = scenes,
                 )
             )
         }
@@ -131,6 +158,18 @@ object StoryRepository {
                 envArray.put(eObj)
             }
             obj.put("environments", envArray)
+            val sceneArray = JSONArray()
+            s.scenes.forEach { scene ->
+                val scObj = JSONObject()
+                scObj.put("text", scene.text)
+                scene.environment?.let { scObj.put("environment", it.name) }
+                val charNames = JSONArray()
+                scene.characters.forEach { c -> charNames.put(c.name) }
+                scObj.put("characters", charNames)
+                scene.image?.let { scObj.put("image", it) }
+                sceneArray.put(scObj)
+            }
+            obj.put("scenes", sceneArray)
             array.put(obj)
         }
         val file = File(context.filesDir, FILE_NAME)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -30,6 +30,7 @@
     <string name="back">Retour</string>
     <string name="characters_title">Personnages</string>
     <string name="environments_title">Environnements</string>
+    <string name="scenes_title">Scènes</string>
     <string name="image_style">Style d\'image</string>
     <string name="style_photorealistic">Photorealiste</string>
     <string name="style_cartoon">Cartoon</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -30,6 +30,7 @@
     <string name="back">Indietro</string>
     <string name="characters_title">Personaggi</string>
     <string name="environments_title">Ambientazioni</string>
+    <string name="scenes_title">Scene</string>
     <string name="image_style">Stile immagine</string>
     <string name="style_photorealistic">Fotorealistico</string>
     <string name="style_cartoon">Cartoon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="back">Back</string>
     <string name="characters_title">Characters</string>
     <string name="environments_title">Environments</string>
+    <string name="scenes_title">Scenes</string>
     <string name="image_style">Image style</string>
     <string name="style_photorealistic">Photorealistic</string>
     <string name="style_cartoon">Cartoon</string>


### PR DESCRIPTION
## Summary
- Add `Scene` model and persist scenes with stories
- Compose scenes via LLM and generate scene images
- Display scene-by-scene narrative with illustrations

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b3222275a483258bef92388cef6552