### PR TITLE
Increase Gradle heap size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
+
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Summary
- raise Gradle JVM heap to 4g to prevent OutOfMemory errors during dexing

## Testing
- `./gradlew lint` *(fails: Installed Build Tools revision 34.0.0 is corrupted)*
- `./gradlew test` *(fails: Installed Build Tools revision 34.0.0 is corrupted)*
- `./gradlew assembleRelease` *(fails: Installed Build Tools revision 34.0.0 is corrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68b34d61386083259afa6bbaac8f6477