### PR TITLE
Enable full-screen image viewing

### DIFF
--- a/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
@@ -2,6 +2,7 @@ package com.immagineran.no
 
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -17,14 +18,18 @@ import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 
 /**
  * Displays a story's details using a tabbed layout reminiscent of classic starship interfaces.
@@ -105,6 +110,7 @@ private fun StoryContent(story: Story) {
 
 @Composable
 private fun CharacterList(characters: List<CharacterAsset>) {
+    var selectedImage by remember { mutableStateOf<String?>(null) }
     LazyColumn(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
         item { Text(stringResource(R.string.characters_title), style = MaterialTheme.typography.h6) }
         items(characters) { c ->
@@ -115,7 +121,9 @@ private fun CharacterList(characters: List<CharacterAsset>) {
                         Image(
                             bitmap = bmp.asImageBitmap(),
                             contentDescription = c.name,
-                            modifier = Modifier.size(64.dp)
+                            modifier = Modifier
+                                .size(64.dp)
+                                .clickable { selectedImage = it }
                         )
                     }
                 }
@@ -129,10 +137,14 @@ private fun CharacterList(characters: List<CharacterAsset>) {
             }
         }
     }
+    selectedImage?.let {
+        FullScreenImage(imagePath = it) { selectedImage = null }
+    }
 }
 
 @Composable
 private fun EnvironmentList(environments: List<EnvironmentAsset>) {
+    var selectedImage by remember { mutableStateOf<String?>(null) }
     LazyColumn(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
         item { Text(stringResource(R.string.environments_title), style = MaterialTheme.typography.h6) }
         items(environments) { e ->
@@ -143,7 +155,9 @@ private fun EnvironmentList(environments: List<EnvironmentAsset>) {
                         Image(
                             bitmap = bmp.asImageBitmap(),
                             contentDescription = e.name,
-                            modifier = Modifier.size(64.dp)
+                            modifier = Modifier
+                                .size(64.dp)
+                                .clickable { selectedImage = it }
                         )
                     }
                 }
@@ -157,10 +171,14 @@ private fun EnvironmentList(environments: List<EnvironmentAsset>) {
             }
         }
     }
+    selectedImage?.let {
+        FullScreenImage(imagePath = it) { selectedImage = null }
+    }
 }
 
 @Composable
 private fun SceneList(scenes: List<Scene>) {
+    var selectedImage by remember { mutableStateOf<String?>(null) }
     LazyColumn(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
         item { Text(stringResource(R.string.scenes_title), style = MaterialTheme.typography.h6) }
         items(scenes) { s ->
@@ -174,6 +192,7 @@ private fun SceneList(scenes: List<Scene>) {
                             modifier = Modifier
                                 .height(128.dp)
                                 .fillMaxWidth()
+                                .clickable { selectedImage = it }
                         )
                     }
                 }
@@ -181,6 +200,29 @@ private fun SceneList(scenes: List<Scene>) {
                 if (s.image == null) {
                     Text(stringResource(R.string.image_generation_error))
                 }
+            }
+        }
+    }
+    selectedImage?.let {
+        FullScreenImage(imagePath = it) { selectedImage = null }
+    }
+}
+
+@Composable
+private fun FullScreenImage(imagePath: String, onDismiss: () -> Unit) {
+    val bmp = BitmapFactory.decodeFile(imagePath)
+    if (bmp != null) {
+        Dialog(
+            onDismissRequest = onDismiss,
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Image(
+                    bitmap = bmp.asImageBitmap(),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Fit
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow tapping character, environment, and scene images to view them full-screen
- add reusable composable for full-screen image dialog

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e04adc00832587e948232919fe52