### PR TITLE
Use resource templates for image generation prompts

### DIFF
--- a/app/src/main/java/com/immagineran/no/ImageGenerator.kt
+++ b/app/src/main/java/com/immagineran/no/ImageGenerator.kt
@@ -18,10 +18,10 @@ class ImageGenerator(
     private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance(),
 ) {
     /**
-     * Generates an image based on the given [description] and [style].
+     * Generates an image based on the given [prompt].
      * Retries up to five times if the response does not contain an image.
      */
-    suspend fun generate(description: String, style: ImageStyle, file: File): String? = withContext(Dispatchers.IO) {
+    suspend fun generate(prompt: String, file: File): String? = withContext(Dispatchers.IO) {
         val key = BuildConfig.OPENROUTER_API_KEY
         if (key.isBlank()) {
             Log.e("ImageGenerator", "Missing OpenRouter API key")
@@ -30,7 +30,7 @@ class ImageGenerator(
         }
         runCatching {
             val messages = JSONArray().apply {
-                put(message("Generate a ${style.prompt} character sheet from the following description: ${description}"))
+                put(message(prompt))
             }
             repeat(5) { attempt ->
                 val root = JSONObject().apply {

--- a/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
@@ -71,12 +71,14 @@ class ImageGenerationStep(
         val style = SettingsManager.getImageStyle(appContext)
         context.characters = context.characters.mapIndexed { idx, asset ->
             val file = File(dir, "character_${idx}.png")
-            val path = generator.generate(asset.description, style, file)
+            val prompt = PromptTemplates.load(appContext, R.raw.character_image_prompt, style, asset.description)
+            val path = generator.generate(prompt, file)
             asset.copy(image = path)
         }
         context.environments = context.environments.mapIndexed { idx, asset ->
             val file = File(dir, "environment_${idx}.png")
-            val path = generator.generate(asset.description, style, file)
+            val prompt = PromptTemplates.load(appContext, R.raw.environment_image_prompt, style, asset.description)
+            val path = generator.generate(prompt, file)
             asset.copy(image = path)
         }
     }

--- a/app/src/main/java/com/immagineran/no/PromptTemplates.kt
+++ b/app/src/main/java/com/immagineran/no/PromptTemplates.kt
@@ -1,0 +1,20 @@
+package com.immagineran.no
+
+import android.content.Context
+import androidx.annotation.RawRes
+
+/**
+ * Utility for loading prompt templates from raw resources and applying data.
+ */
+object PromptTemplates {
+    /**
+     * Loads a template from [resId] and replaces placeholders with [style] and [description].
+     */
+    fun load(context: Context, @RawRes resId: Int, style: ImageStyle, description: String): String {
+        val template = context.resources.openRawResource(resId).bufferedReader().use { it.readText() }
+        return template
+            .replace("{STYLE}", style.prompt)
+            .replace("{DESCRIPTION}", description)
+    }
+}
+

--- a/app/src/main/java/com/immagineran/no/SceneSteps.kt
+++ b/app/src/main/java/com/immagineran/no/SceneSteps.kt
@@ -29,7 +29,8 @@ class SceneImageGenerationStep(
                     append(scene.characters.joinToString { it.description })
                 }
             }
-            val path = generator.generate(description, style, file)
+            val prompt = PromptTemplates.load(appContext, R.raw.scene_image_prompt, style, description)
+            val path = generator.generate(prompt, file)
             scene.copy(image = path)
         }
     }

--- a/app/src/main/res/raw/character_image_prompt.txt
+++ b/app/src/main/res/raw/character_image_prompt.txt
@@ -1,0 +1,1 @@
+Generate a {STYLE} character sheet from the following description: {DESCRIPTION}

--- a/app/src/main/res/raw/environment_image_prompt.txt
+++ b/app/src/main/res/raw/environment_image_prompt.txt
@@ -1,0 +1,1 @@
+Generate a {STYLE} environment concept art from the following description: {DESCRIPTION}

--- a/app/src/main/res/raw/scene_image_prompt.txt
+++ b/app/src/main/res/raw/scene_image_prompt.txt
@@ -1,0 +1,1 @@
+Generate a {STYLE} scene from the following description: {DESCRIPTION}


### PR DESCRIPTION
## Summary
- Load prompt templates from raw resources and apply style and description placeholders
- Allow ImageGenerator to accept a complete prompt string
- Use distinct prompts for character, environment, and scene images

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e378a39c832583786b60a988a37f