### PR TITLE
Allow closing full-screen images with a tap

### DIFF
--- a/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
@@ -216,7 +216,12 @@ private fun FullScreenImage(imagePath: String, onDismiss: () -> Unit) {
             onDismissRequest = onDismiss,
             properties = DialogProperties(usePlatformDefaultWidth = false)
         ) {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable(onClick = onDismiss),
+                contentAlignment = Alignment.Center
+            ) {
                 Image(
                     bitmap = bmp.asImageBitmap(),
                     contentDescription = null,


### PR DESCRIPTION
## Summary
- make full-screen images dismiss on tap

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b3efeb520883258f327692372ef9a6