### PR TITLE
Strip base64 image data from LLM logs

### DIFF
--- a/app/src/main/java/com/immagineran/no/LlmLogger.kt
+++ b/app/src/main/java/com/immagineran/no/LlmLogger.kt
@@ -14,18 +14,32 @@ object LlmLogger {
 
     /**
      * Appends a log entry containing the raw [request] and [response].
+     * Any embedded base64 data is stripped to keep logs small.
      */
     fun log(context: Context, tag: String, request: String, response: String?) {
         val timestamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US).format(Date())
         val entry = buildString {
             append(timestamp).append(' ').append('[').append(tag).append("]\n")
-            append("REQUEST:\n").append(request).append("\n")
-            response?.let { append("RESPONSE:\n").append(it).append("\n") }
+            append("REQUEST:\n").append(stripBase64(request)).append("\n")
+            response?.let { append("RESPONSE:\n").append(stripBase64(it)).append("\n") }
             append("\n")
         }
         context.openFileOutput(FILE_NAME, Context.MODE_APPEND).use { out ->
             out.write(entry.toByteArray())
         }
+    }
+
+    /**
+     * Removes base64 encoded image data from [content].
+     */
+    private fun stripBase64(content: String): String {
+        val urlRegex = Regex("data:image/[^;]+;base64,[A-Za-z0-9+/=\\r\\n]+")
+        val fieldRegex = Regex("\"image_base64\"\\s*:\\s*\"[A-Za-z0-9+/=\\r\\n]+\"")
+        return content
+            .replace(urlRegex) { match ->
+                match.value.substringBefore("base64,") + "<base64 removed>"
+            }
+            .replace(fieldRegex, "\"image_base64\":\"<base64 removed>\"")
     }
 
     /**


### PR DESCRIPTION
## Summary
- sanitize LLM request/response logs by removing embedded base64 image data to avoid oversized log files

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b40c06c4088325b5d1353ff6aee071