### PR TITLE
Share LLM logs as file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,15 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/immagineran/no/SettingsScreen.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package com.immagineran.no
 
 import android.content.Intent
+import androidx.core.content.FileProvider
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
@@ -60,12 +61,23 @@ fun SettingsScreen(onBack: () -> Unit) {
         Button(
             onClick = {
                 val logs = LlmLogger.getLogFile(context)
-                val text = if (logs.exists()) logs.readText() else ""
+                if (!logs.exists()) logs.createNewFile()
+                val uri = FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.provider",
+                    logs,
+                )
                 val sendIntent = Intent(Intent.ACTION_SEND).apply {
                     type = "text/plain"
-                    putExtra(Intent.EXTRA_TEXT, text)
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
-                context.startActivity(Intent.createChooser(sendIntent, context.getString(R.string.share_llm_logs)))
+                context.startActivity(
+                    Intent.createChooser(
+                        sendIntent,
+                        context.getString(R.string.share_llm_logs),
+                    ),
+                )
             },
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="logs" path="." />
+</paths>


### PR DESCRIPTION
## Summary
- Share LLM logs using a file rather than clipboard text
- Add FileProvider and file path configuration for log file access

## Testing
- `./gradlew lint`
- `./gradlew test --console=plain --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68b410d6c5588325a817a4f48c7f95df