### PR TITLE
feat: add editable story titles with timestamps

### DIFF
--- a/app/src/main/java/com/immagineran/no/Story.kt
+++ b/app/src/main/java/com/immagineran/no/Story.kt
@@ -22,6 +22,7 @@ data class Scene(
 data class Story(
     val id: Long,
     val title: String,
+    val timestamp: Long,
     val content: String,
     val segments: List<String> = emptyList(),
     val processed: Boolean = false,

--- a/app/src/main/java/com/immagineran/no/StoryRepository.kt
+++ b/app/src/main/java/com/immagineran/no/StoryRepository.kt
@@ -81,6 +81,7 @@ object StoryRepository {
                 Story(
                     id = obj.getLong("id"),
                     title = obj.getString("title"),
+                    timestamp = obj.optLong("timestamp", System.currentTimeMillis()),
                     content = obj.optString("content", ""),
                     segments = segments,
                     processed = obj.optBoolean("processed", false),
@@ -135,6 +136,7 @@ object StoryRepository {
             val obj = JSONObject()
             obj.put("id", s.id)
             obj.put("title", s.title)
+            obj.put("timestamp", s.timestamp)
             obj.put("content", s.content)
             obj.put("processed", s.processed)
             val segmentsArray = JSONArray()

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,4 +41,6 @@
     <string name="share_llm_logs">Partager les journaux LLM</string>
     <string name="clear_llm_logs">Effacer les journaux LLM</string>
     <string name="advanced">Avancé</string>
+    <string name="edit_title">Modifier le titre</string>
+    <string name="save_title">Enregistrer le titre</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -41,4 +41,6 @@
     <string name="share_llm_logs">Condividi log LLM</string>
     <string name="clear_llm_logs">Cancella log LLM</string>
     <string name="advanced">Avanzate</string>
+    <string name="edit_title">Modifica titolo</string>
+    <string name="save_title">Salva titolo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,6 @@
     <string name="share_llm_logs">Share LLM logs</string>
     <string name="clear_llm_logs">Clear LLM logs</string>
     <string name="advanced">Advanced</string>
+    <string name="edit_title">Edit title</string>
+    <string name="save_title">Save title</string>
 </resources>


### PR DESCRIPTION
## Summary
- add top bar settings icon for easier access
- allow editing story titles during creation and in details view
- persist story timestamps and show them under titles

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b423f415bc8325a2904544e0c86647