### PR TITLE
Add experimental structured outputs toggle

### DIFF
--- a/app/src/main/java/com/immagineran/no/SettingsManager.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 private const val PREFS_NAME = "app_settings"
 private const val KEY_TRANSCRIPTION_METHOD = "transcription_method"
 private const val KEY_IMAGE_STYLE = "image_style"
+private const val KEY_STRUCTURED_OUTPUTS = "structured_outputs"
 
 /**
  * Persists user-configurable settings.
@@ -38,6 +39,22 @@ object SettingsManager {
     fun setImageStyle(context: Context, style: ImageStyle) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         prefs.edit().putString(KEY_IMAGE_STYLE, style.name).apply()
+    }
+
+    /**
+     * Determines whether structured outputs are enabled.
+     */
+    fun useStructuredOutputs(context: Context): Boolean {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getBoolean(KEY_STRUCTURED_OUTPUTS, false)
+    }
+
+    /**
+     * Persists the structured output preference.
+     */
+    fun setUseStructuredOutputs(context: Context, enabled: Boolean) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(KEY_STRUCTURED_OUTPUTS, enabled).apply()
     }
 }
 

--- a/app/src/main/java/com/immagineran/no/SettingsScreen.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RadioButton
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -19,6 +20,9 @@ fun SettingsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     var selectedTranscription by remember { mutableStateOf(SettingsManager.getTranscriptionMethod(context)) }
     var selectedStyle by remember { mutableStateOf(SettingsManager.getImageStyle(context)) }
+    var useStructuredOutputs by remember {
+        mutableStateOf(SettingsManager.useStructuredOutputs(context))
+    }
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text(text = stringResource(R.string.settings_title), style = MaterialTheme.typography.h5)
         Spacer(modifier = Modifier.height(16.dp))
@@ -102,11 +106,31 @@ fun SettingsScreen(onBack: () -> Unit) {
         ) {
             Text(text = stringResource(R.string.test_crash))
         }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.experimental_features),
+            style = MaterialTheme.typography.h6,
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        ) {
+            Text(text = stringResource(R.string.use_structured_outputs))
+            Spacer(modifier = Modifier.weight(1f))
+            Switch(
+                checked = useStructuredOutputs,
+                onCheckedChange = { useStructuredOutputs = it },
+            )
+        }
         Spacer(modifier = Modifier.weight(1f))
         Button(
             onClick = {
                 SettingsManager.setTranscriptionMethod(context, selectedTranscription)
                 SettingsManager.setImageStyle(context, selectedStyle)
+                SettingsManager.setUseStructuredOutputs(
+                    context,
+                    useStructuredOutputs,
+                )
                 onBack()
             },
             modifier = Modifier.align(Alignment.CenterHorizontally),

--- a/app/src/main/java/com/immagineran/no/StoryAssetExtractor.kt
+++ b/app/src/main/java/com/immagineran/no/StoryAssetExtractor.kt
@@ -27,12 +27,47 @@ class StoryAssetExtractor(
         runCatching {
             val root = JSONObject().apply {
                 put("model", "mistralai/mistral-nemo")
-                put("messages", JSONArray().apply {
-                    put(JSONObject().apply {
-                        put("role", "user")
-                        put("content", prompt)
-                    })
-                })
+                put(
+                    "messages",
+                    JSONArray().apply {
+                        put(
+                            JSONObject().apply {
+                                put("role", "user")
+                                put("content", prompt)
+                            },
+                        )
+                    },
+                )
+                if (SettingsManager.useStructuredOutputs(appContext)) {
+                    val schema = JSONObject(
+                        """
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": { "type": "string" },
+                              "description": { "type": "string" }
+                            },
+                            "required": ["name", "description"]
+                          }
+                        }
+                        """.trimIndent(),
+                    )
+                    put(
+                        "response_format",
+                        JSONObject().apply {
+                            put("type", "json_schema")
+                            put(
+                                "json_schema",
+                                JSONObject().apply {
+                                    put("name", "assets")
+                                    put("schema", schema)
+                                },
+                            )
+                        },
+                    )
+                }
             }
             val reqJson = root.toString()
             val body = reqJson.toRequestBody("application/json".toMediaType())
@@ -53,10 +88,18 @@ class StoryAssetExtractor(
                 val json = JSONObject(respBody ?: return@withContext null)
                 val choices = json.optJSONArray("choices") ?: return@withContext null
                 if (choices.length() == 0) return@withContext null
-                val content = choices.getJSONObject(0)
-                    .optJSONObject("message")
-                    ?.optString("content") ?: return@withContext null
-                JSONArray(content)
+                val message = choices.getJSONObject(0).optJSONObject("message")
+                    ?: return@withContext null
+                val parsed = message.opt("parsed")
+                when (parsed) {
+                    is JSONArray -> parsed
+                    is JSONObject -> JSONArray().put(parsed)
+                    else -> {
+                        val content = message.optString("content")
+                        if (content.isBlank()) return@withContext null
+                        JSONArray(content)
+                    }
+                }
             }
         }.getOrElse { e ->
             Log.e("StoryAssetExtractor", "LLM error", e)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,6 +41,8 @@
     <string name="share_llm_logs">Partager les journaux LLM</string>
     <string name="clear_llm_logs">Effacer les journaux LLM</string>
     <string name="advanced">Avancé</string>
+    <string name="experimental_features">Fonctionnalités expérimentales</string>
+    <string name="use_structured_outputs">Utiliser les sorties structurées</string>
     <string name="edit_title">Modifier le titre</string>
     <string name="save_title">Enregistrer le titre</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -41,6 +41,8 @@
     <string name="share_llm_logs">Condividi log LLM</string>
     <string name="clear_llm_logs">Cancella log LLM</string>
     <string name="advanced">Avanzate</string>
+    <string name="experimental_features">Funzionalità sperimentali</string>
+    <string name="use_structured_outputs">Usa output strutturati</string>
     <string name="edit_title">Modifica titolo</string>
     <string name="save_title">Salva titolo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="share_llm_logs">Share LLM logs</string>
     <string name="clear_llm_logs">Clear LLM logs</string>
     <string name="advanced">Advanced</string>
+    <string name="experimental_features">Experimental features</string>
+    <string name="use_structured_outputs">Use structured outputs</string>
     <string name="edit_title">Edit title</string>
     <string name="save_title">Save title</string>
 </resources>


### PR DESCRIPTION
## Summary
- add experimental features section to settings with toggle for structured outputs
- support OpenRouter structured outputs in LLM calls when experimental toggle enabled
- document new settings strings in English, Italian and French

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b42a357d748325af334529a091d7f2