### PR TITLE
Enable structured outputs by default

### DIFF
--- a/app/src/main/java/com/immagineran/no/SettingsManager.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsManager.kt
@@ -5,7 +5,6 @@ import android.content.Context
 private const val PREFS_NAME = "app_settings"
 private const val KEY_TRANSCRIPTION_METHOD = "transcription_method"
 private const val KEY_IMAGE_STYLE = "image_style"
-private const val KEY_STRUCTURED_OUTPUTS = "structured_outputs"
 
 /**
  * Persists user-configurable settings.
@@ -42,19 +41,9 @@ object SettingsManager {
     }
 
     /**
-     * Determines whether structured outputs are enabled.
+     * Structured outputs are always enabled.
      */
-    fun useStructuredOutputs(context: Context): Boolean {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        return prefs.getBoolean(KEY_STRUCTURED_OUTPUTS, false)
-    }
-
-    /**
-     * Persists the structured output preference.
-     */
-    fun setUseStructuredOutputs(context: Context, enabled: Boolean) {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        prefs.edit().putBoolean(KEY_STRUCTURED_OUTPUTS, enabled).apply()
-    }
+    @Suppress("UNUSED_PARAMETER")
+    fun useStructuredOutputs(context: Context): Boolean = true
 }
 

--- a/app/src/main/java/com/immagineran/no/SettingsScreen.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RadioButton
-import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -20,9 +19,6 @@ fun SettingsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     var selectedTranscription by remember { mutableStateOf(SettingsManager.getTranscriptionMethod(context)) }
     var selectedStyle by remember { mutableStateOf(SettingsManager.getImageStyle(context)) }
-    var useStructuredOutputs by remember {
-        mutableStateOf(SettingsManager.useStructuredOutputs(context))
-    }
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text(text = stringResource(R.string.settings_title), style = MaterialTheme.typography.h5)
         Spacer(modifier = Modifier.height(16.dp))
@@ -106,31 +102,11 @@ fun SettingsScreen(onBack: () -> Unit) {
         ) {
             Text(text = stringResource(R.string.test_crash))
         }
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = stringResource(R.string.experimental_features),
-            style = MaterialTheme.typography.h6,
-        )
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-        ) {
-            Text(text = stringResource(R.string.use_structured_outputs))
-            Spacer(modifier = Modifier.weight(1f))
-            Switch(
-                checked = useStructuredOutputs,
-                onCheckedChange = { useStructuredOutputs = it },
-            )
-        }
         Spacer(modifier = Modifier.weight(1f))
         Button(
             onClick = {
                 SettingsManager.setTranscriptionMethod(context, selectedTranscription)
                 SettingsManager.setImageStyle(context, selectedStyle)
-                SettingsManager.setUseStructuredOutputs(
-                    context,
-                    useStructuredOutputs,
-                )
                 onBack()
             },
             modifier = Modifier.align(Alignment.CenterHorizontally),

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,8 +41,6 @@
     <string name="share_llm_logs">Partager les journaux LLM</string>
     <string name="clear_llm_logs">Effacer les journaux LLM</string>
     <string name="advanced">Avancé</string>
-    <string name="experimental_features">Fonctionnalités expérimentales</string>
-    <string name="use_structured_outputs">Utiliser les sorties structurées</string>
     <string name="edit_title">Modifier le titre</string>
     <string name="save_title">Enregistrer le titre</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -41,8 +41,6 @@
     <string name="share_llm_logs">Condividi log LLM</string>
     <string name="clear_llm_logs">Cancella log LLM</string>
     <string name="advanced">Avanzate</string>
-    <string name="experimental_features">Funzionalità sperimentali</string>
-    <string name="use_structured_outputs">Usa output strutturati</string>
     <string name="edit_title">Modifica titolo</string>
     <string name="save_title">Salva titolo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,8 +41,6 @@
     <string name="share_llm_logs">Share LLM logs</string>
     <string name="clear_llm_logs">Clear LLM logs</string>
     <string name="advanced">Advanced</string>
-    <string name="experimental_features">Experimental features</string>
-    <string name="use_structured_outputs">Use structured outputs</string>
     <string name="edit_title">Edit title</string>
     <string name="save_title">Save title</string>
 </resources>


### PR DESCRIPTION
## Summary
- Always enable structured outputs and remove preference toggle
- Simplify settings screen by dropping experimental features section
- Clean up unused strings across locales

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b46a1cd2f88325a7cff38559c461ce