### PR TITLE
Show progress screen during story processing

### DIFF
--- a/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
@@ -27,8 +27,14 @@ fun interface ProcessingStep {
  * Simple pipeline executing a list of [ProcessingStep]s sequentially.
  */
 class ProcessingPipeline(private val steps: List<ProcessingStep>) {
-    suspend fun run(context: ProcessingContext): ProcessingContext {
-        steps.forEach { it.process(context) }
+    suspend fun run(
+        context: ProcessingContext,
+        onProgress: suspend (current: Int, total: Int, message: String) -> Unit = { _, _, _ -> }
+    ): ProcessingContext {
+        steps.forEachIndexed { index, step ->
+            step.process(context)
+            onProgress(index + 1, steps.size, step.javaClass.simpleName)
+        }
         return context
     }
 }

--- a/app/src/main/java/com/immagineran/no/ProcessingScreen.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingScreen.kt
@@ -1,0 +1,44 @@
+package com.immagineran.no
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+
+/**
+ * Screen displaying progress of the processing pipeline.
+ *
+ * @param progress Value between 0f and 1f indicating completion percentage.
+ * @param logs Log messages to show in a terminal-like list.
+ */
+@Composable
+fun ProcessingScreen(progress: Float, logs: List<String>) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(text = stringResource(R.string.processing), style = MaterialTheme.typography.h6)
+        Spacer(modifier = Modifier.height(8.dp))
+        LinearProgressIndicator(progress = progress, modifier = Modifier.fillMaxWidth())
+        Spacer(modifier = Modifier.height(8.dp))
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colors.onSurface.copy(alpha = 0.05f))
+        ) {
+            items(logs) { log ->
+                Text(text = log, fontFamily = FontFamily.Monospace, modifier = Modifier.padding(4.dp))
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -43,4 +43,6 @@
     <string name="advanced">Avancé</string>
     <string name="edit_title">Modifier le titre</string>
     <string name="save_title">Enregistrer le titre</string>
+    <string name="processing">Traitement</string>
+    <string name="processing_complete">Traitement terminé</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -43,4 +43,6 @@
     <string name="advanced">Avanzate</string>
     <string name="edit_title">Modifica titolo</string>
     <string name="save_title">Salva titolo</string>
+    <string name="processing">Elaborazione</string>
+    <string name="processing_complete">Elaborazione completata</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,6 @@
     <string name="advanced">Advanced</string>
     <string name="edit_title">Edit title</string>
     <string name="save_title">Save title</string>
+    <string name="processing">Processing</string>
+    <string name="processing_complete">Processing complete</string>
 </resources>


### PR DESCRIPTION
## Summary
- add dedicated processing screen with progress bar and terminal-style log
- support progress callbacks in processing pipeline
- show processing screen when finishing recording

## Testing
- `./gradlew lint` (fails: Task :app:generateDebugBuildConfig; build incomplete)
- `./gradlew test` (fails: requires Android SDK Platform 34 installation)

------
https://chatgpt.com/codex/tasks/task_e_68b483500e08832599af6a028b83a050