### PR TITLE
Fix processing log string interpolation

### DIFF
--- a/app/src/main/java/com/immagineran/no/MainActivity.kt
+++ b/app/src/main/java/com/immagineran/no/MainActivity.kt
@@ -102,7 +102,11 @@ class MainActivity : ComponentActivity() {
                                                     pipeline.run(procContext) { current, total, message ->
                                                         withContext(Dispatchers.Main) {
                                                             processingProgress = current / total.toFloat()
-                                                            processingLogs.add("Step ${'$'}current/${'$'}total: ${'$'}message")
+                                                            val stepName = message
+                                                                .removeSuffix("Step")
+                                                                .replace(Regex("([a-z])([A-Z])"), "$1 $2")
+                                                                .uppercase()
+                                                            processingLogs.add("[$current/$total] >>> $stepName")
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
## Summary
- fix broken string interpolation in processing logs
- enhance log messages with verbose hacker-style step info

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b54b16b3248325982e8d9332b85158