### PR TITLE
feat: add optional asset image generation

### DIFF
--- a/app/src/main/java/com/immagineran/no/AdvancedOptionsScreen.kt
+++ b/app/src/main/java/com/immagineran/no/AdvancedOptionsScreen.kt
@@ -1,0 +1,97 @@
+package com.immagineran.no
+
+import android.content.Intent
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+
+/**
+ * Screen presenting advanced options and utilities.
+ */
+@Composable
+fun AdvancedOptionsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    var generateImages by remember { mutableStateOf(SettingsManager.isAssetImageGenerationEnabled(context)) }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        Text(text = stringResource(R.string.advanced), style = MaterialTheme.typography.h5)
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.generate_asset_images),
+                modifier = Modifier.weight(1f),
+            )
+            Switch(checked = generateImages, onCheckedChange = { generateImages = it })
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = {
+                val logs = LlmLogger.getLogFile(context)
+                if (!logs.exists()) logs.createNewFile()
+                val uri = FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.provider",
+                    logs,
+                )
+                val sendIntent = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                context.startActivity(
+                    Intent.createChooser(
+                        sendIntent,
+                        context.getString(R.string.share_llm_logs),
+                    ),
+                )
+            },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text(text = stringResource(R.string.share_llm_logs))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = { LlmLogger.clear(context) },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text(text = stringResource(R.string.clear_llm_logs))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = { throw RuntimeException("Test Crash") },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text(text = stringResource(R.string.test_crash))
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        Button(
+            onClick = {
+                SettingsManager.setAssetImageGenerationEnabled(context, generateImages)
+                onBack()
+            },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text(text = stringResource(R.string.save))
+        }
+    }
+}

--- a/app/src/main/java/com/immagineran/no/SettingsManager.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 private const val PREFS_NAME = "app_settings"
 private const val KEY_TRANSCRIPTION_METHOD = "transcription_method"
 private const val KEY_IMAGE_STYLE = "image_style"
+private const val KEY_GENERATE_ASSET_IMAGES = "generate_asset_images"
 
 /**
  * Persists user-configurable settings.
@@ -38,6 +39,22 @@ object SettingsManager {
     fun setImageStyle(context: Context, style: ImageStyle) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         prefs.edit().putString(KEY_IMAGE_STYLE, style.name).apply()
+    }
+
+    /**
+     * Returns whether character and environment images should be generated.
+     */
+    fun isAssetImageGenerationEnabled(context: Context): Boolean {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getBoolean(KEY_GENERATE_ASSET_IMAGES, true)
+    }
+
+    /**
+     * Persists the asset image generation preference.
+     */
+    fun setAssetImageGenerationEnabled(context: Context, enabled: Boolean) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(KEY_GENERATE_ASSET_IMAGES, enabled).apply()
     }
 
     /**

--- a/app/src/main/java/com/immagineran/no/SettingsScreen.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsScreen.kt
@@ -1,7 +1,5 @@
 package com.immagineran.no
 
-import android.content.Intent
-import androidx.core.content.FileProvider
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
@@ -15,7 +13,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun SettingsScreen(onBack: () -> Unit) {
+fun SettingsScreen(onBack: () -> Unit, onAdvanced: () -> Unit) {
     val context = LocalContext.current
     var selectedTranscription by remember { mutableStateOf(SettingsManager.getTranscriptionMethod(context)) }
     var selectedStyle by remember { mutableStateOf(SettingsManager.getImageStyle(context)) }
@@ -58,49 +56,11 @@ fun SettingsScreen(onBack: () -> Unit) {
             }
         }
         Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = stringResource(R.string.advanced),
-            style = MaterialTheme.typography.h6,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
         Button(
-            onClick = {
-                val logs = LlmLogger.getLogFile(context)
-                if (!logs.exists()) logs.createNewFile()
-                val uri = FileProvider.getUriForFile(
-                    context,
-                    "${context.packageName}.provider",
-                    logs,
-                )
-                val sendIntent = Intent(Intent.ACTION_SEND).apply {
-                    type = "text/plain"
-                    putExtra(Intent.EXTRA_STREAM, uri)
-                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                }
-                context.startActivity(
-                    Intent.createChooser(
-                        sendIntent,
-                        context.getString(R.string.share_llm_logs),
-                    ),
-                )
-            },
+            onClick = onAdvanced,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
-            Text(text = stringResource(R.string.share_llm_logs))
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(
-            onClick = { LlmLogger.clear(context) },
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) {
-            Text(text = stringResource(R.string.clear_llm_logs))
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(
-            onClick = { throw RuntimeException("Test Crash") },
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) {
-            Text(text = stringResource(R.string.test_crash))
+            Text(text = stringResource(R.string.advanced))
         }
         Spacer(modifier = Modifier.weight(1f))
         Button(

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,6 +41,7 @@
     <string name="share_llm_logs">Partager les journaux LLM</string>
     <string name="clear_llm_logs">Effacer les journaux LLM</string>
     <string name="advanced">Avancé</string>
+    <string name="generate_asset_images">Générer des images de personnages et d\'environnements</string>
     <string name="edit_title">Modifier le titre</string>
     <string name="save_title">Enregistrer le titre</string>
     <string name="processing">Traitement</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -41,6 +41,7 @@
     <string name="share_llm_logs">Condividi log LLM</string>
     <string name="clear_llm_logs">Cancella log LLM</string>
     <string name="advanced">Avanzate</string>
+    <string name="generate_asset_images">Genera immagini di personaggi e ambientazioni</string>
     <string name="edit_title">Modifica titolo</string>
     <string name="save_title">Salva titolo</string>
     <string name="processing">Elaborazione</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="share_llm_logs">Share LLM logs</string>
     <string name="clear_llm_logs">Clear LLM logs</string>
     <string name="advanced">Advanced</string>
+    <string name="generate_asset_images">Generate character and environment images</string>
     <string name="edit_title">Edit title</string>
     <string name="save_title">Save title</string>
     <string name="processing">Processing</string>


### PR DESCRIPTION
## Summary
- add scrollable advanced options screen with toggle for character/environment image generation
- allow navigating to advanced options from settings and store preference
- skip asset image generation step when disabled

## Testing
- `./gradlew lint`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b600ec91288325a6ea0245175e5e24