### PR TITLE
Make asset image generation steps optional

### DIFF
--- a/app/src/main/java/com/immagineran/no/AdvancedOptionsScreen.kt
+++ b/app/src/main/java/com/immagineran/no/AdvancedOptionsScreen.kt
@@ -22,7 +22,12 @@ import androidx.core.content.FileProvider
 @Composable
 fun AdvancedOptionsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
-    var generateImages by remember { mutableStateOf(SettingsManager.isAssetImageGenerationEnabled(context)) }
+    var generateCharacterImages by remember {
+        mutableStateOf(SettingsManager.isCharacterImageGenerationEnabled(context))
+    }
+    var generateEnvironmentImages by remember {
+        mutableStateOf(SettingsManager.isEnvironmentImageGenerationEnabled(context))
+    }
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -38,10 +43,28 @@ fun AdvancedOptionsScreen(onBack: () -> Unit) {
                 .padding(vertical = 4.dp),
         ) {
             Text(
-                text = stringResource(R.string.generate_asset_images),
+                text = stringResource(R.string.generate_character_images),
                 modifier = Modifier.weight(1f),
             )
-            Switch(checked = generateImages, onCheckedChange = { generateImages = it })
+            Switch(
+                checked = generateCharacterImages,
+                onCheckedChange = { generateCharacterImages = it },
+            )
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.generate_environment_images),
+                modifier = Modifier.weight(1f),
+            )
+            Switch(
+                checked = generateEnvironmentImages,
+                onCheckedChange = { generateEnvironmentImages = it },
+            )
         }
         Spacer(modifier = Modifier.height(8.dp))
         Button(
@@ -86,7 +109,8 @@ fun AdvancedOptionsScreen(onBack: () -> Unit) {
         Spacer(modifier = Modifier.weight(1f))
         Button(
             onClick = {
-                SettingsManager.setAssetImageGenerationEnabled(context, generateImages)
+                SettingsManager.setCharacterImageGenerationEnabled(context, generateCharacterImages)
+                SettingsManager.setEnvironmentImageGenerationEnabled(context, generateEnvironmentImages)
                 onBack()
             },
             modifier = Modifier.align(Alignment.CenterHorizontally),

--- a/app/src/main/java/com/immagineran/no/MainActivity.kt
+++ b/app/src/main/java/com/immagineran/no/MainActivity.kt
@@ -91,12 +91,23 @@ class MainActivity : ComponentActivity() {
                                                     val steps = mutableListOf<ProcessingStep>(
                                                         StoryStitchingStep(this@MainActivity),
                                                         CharacterExtractionStep(this@MainActivity),
-                                                        EnvironmentExtractionStep(this@MainActivity),
-                                                        SceneCompositionStep(this@MainActivity),
                                                     )
-                                                    if (SettingsManager.isAssetImageGenerationEnabled(this@MainActivity)) {
-                                                        steps.add(ImageGenerationStep(this@MainActivity))
+                                                    if (
+                                                        SettingsManager.isCharacterImageGenerationEnabled(
+                                                            this@MainActivity
+                                                        )
+                                                    ) {
+                                                        steps.add(CharacterImageGenerationStep(this@MainActivity))
                                                     }
+                                                    steps.add(EnvironmentExtractionStep(this@MainActivity))
+                                                    if (
+                                                        SettingsManager.isEnvironmentImageGenerationEnabled(
+                                                            this@MainActivity
+                                                        )
+                                                    ) {
+                                                        steps.add(EnvironmentImageGenerationStep(this@MainActivity))
+                                                    }
+                                                    steps.add(SceneCompositionStep(this@MainActivity))
                                                     steps.add(SceneImageGenerationStep(this@MainActivity))
                                                     ProcessingPipeline(steps).run(procContext) { current, total, message ->
                                                         withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
@@ -71,11 +71,12 @@ class EnvironmentExtractionStep(
     }
 }
 
-class ImageGenerationStep(
+class CharacterImageGenerationStep(
     private val appContext: Context,
     private val generator: ImageGenerator = ImageGenerator(appContext),
 ) : ProcessingStep {
     override suspend fun process(context: ProcessingContext) {
+        if (context.characters.isEmpty()) return
         val dir = File(appContext.filesDir, context.id.toString()).apply { mkdirs() }
         val style = SettingsManager.getImageStyle(appContext)
         context.characters = context.characters.mapIndexed { idx, asset ->
@@ -84,6 +85,17 @@ class ImageGenerationStep(
             val path = generator.generate(prompt, file)
             asset.copy(image = path)
         }
+    }
+}
+
+class EnvironmentImageGenerationStep(
+    private val appContext: Context,
+    private val generator: ImageGenerator = ImageGenerator(appContext),
+) : ProcessingStep {
+    override suspend fun process(context: ProcessingContext) {
+        if (context.environments.isEmpty()) return
+        val dir = File(appContext.filesDir, context.id.toString()).apply { mkdirs() }
+        val style = SettingsManager.getImageStyle(appContext)
         context.environments = context.environments.mapIndexed { idx, asset ->
             val file = File(dir, "environment_${idx}.png")
             val prompt = PromptTemplates.load(appContext, R.raw.environment_image_prompt, style, asset.description)

--- a/app/src/main/java/com/immagineran/no/SettingsManager.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsManager.kt
@@ -1,11 +1,14 @@
 package com.immagineran.no
 
 import android.content.Context
+import android.content.SharedPreferences
 
 private const val PREFS_NAME = "app_settings"
 private const val KEY_TRANSCRIPTION_METHOD = "transcription_method"
 private const val KEY_IMAGE_STYLE = "image_style"
 private const val KEY_GENERATE_ASSET_IMAGES = "generate_asset_images"
+private const val KEY_GENERATE_CHARACTER_IMAGES = "generate_character_images"
+private const val KEY_GENERATE_ENVIRONMENT_IMAGES = "generate_environment_images"
 
 /**
  * Persists user-configurable settings.
@@ -41,20 +44,60 @@ object SettingsManager {
         prefs.edit().putString(KEY_IMAGE_STYLE, style.name).apply()
     }
 
-    /**
-     * Returns whether character and environment images should be generated.
-     */
-    fun isAssetImageGenerationEnabled(context: Context): Boolean {
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        return prefs.getBoolean(KEY_GENERATE_ASSET_IMAGES, true)
+    private fun legacyAssetGenerationPreference(prefs: SharedPreferences): Boolean? {
+        return if (prefs.contains(KEY_GENERATE_ASSET_IMAGES)) {
+            prefs.getBoolean(KEY_GENERATE_ASSET_IMAGES, true)
+        } else {
+            null
+        }
     }
 
     /**
-     * Persists the asset image generation preference.
+     * Returns whether character images should be generated.
      */
-    fun setAssetImageGenerationEnabled(context: Context, enabled: Boolean) {
+    fun isCharacterImageGenerationEnabled(context: Context): Boolean {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        prefs.edit().putBoolean(KEY_GENERATE_ASSET_IMAGES, enabled).apply()
+        val legacy = legacyAssetGenerationPreference(prefs)
+        return when {
+            prefs.contains(KEY_GENERATE_CHARACTER_IMAGES) ->
+                prefs.getBoolean(KEY_GENERATE_CHARACTER_IMAGES, true)
+
+            legacy != null -> legacy
+
+            else -> true
+        }
+    }
+
+    /**
+     * Persists the character image generation preference.
+     */
+    fun setCharacterImageGenerationEnabled(context: Context, enabled: Boolean) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(KEY_GENERATE_CHARACTER_IMAGES, enabled).apply()
+    }
+
+    /**
+     * Returns whether environment images should be generated.
+     */
+    fun isEnvironmentImageGenerationEnabled(context: Context): Boolean {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val legacy = legacyAssetGenerationPreference(prefs)
+        return when {
+            prefs.contains(KEY_GENERATE_ENVIRONMENT_IMAGES) ->
+                prefs.getBoolean(KEY_GENERATE_ENVIRONMENT_IMAGES, true)
+
+            legacy != null -> legacy
+
+            else -> true
+        }
+    }
+
+    /**
+     * Persists the environment image generation preference.
+     */
+    fun setEnvironmentImageGenerationEnabled(context: Context, enabled: Boolean) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(KEY_GENERATE_ENVIRONMENT_IMAGES, enabled).apply()
     }
 
     /**

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -41,7 +41,8 @@
     <string name="share_llm_logs">Partager les journaux LLM</string>
     <string name="clear_llm_logs">Effacer les journaux LLM</string>
     <string name="advanced">Avancé</string>
-    <string name="generate_asset_images">Générer des images de personnages et d\'environnements</string>
+    <string name="generate_character_images">Générer des images de personnages</string>
+    <string name="generate_environment_images">Générer des images d\'environnements</string>
     <string name="edit_title">Modifier le titre</string>
     <string name="save_title">Enregistrer le titre</string>
     <string name="processing">Traitement</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -41,7 +41,8 @@
     <string name="share_llm_logs">Condividi log LLM</string>
     <string name="clear_llm_logs">Cancella log LLM</string>
     <string name="advanced">Avanzate</string>
-    <string name="generate_asset_images">Genera immagini di personaggi e ambientazioni</string>
+    <string name="generate_character_images">Genera immagini dei personaggi</string>
+    <string name="generate_environment_images">Genera immagini delle ambientazioni</string>
     <string name="edit_title">Modifica titolo</string>
     <string name="save_title">Salva titolo</string>
     <string name="processing">Elaborazione</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,8 @@
     <string name="share_llm_logs">Share LLM logs</string>
     <string name="clear_llm_logs">Clear LLM logs</string>
     <string name="advanced">Advanced</string>
-    <string name="generate_asset_images">Generate character and environment images</string>
+    <string name="generate_character_images">Generate character images</string>
+    <string name="generate_environment_images">Generate environment images</string>
     <string name="edit_title">Edit title</string>
     <string name="save_title">Save title</string>
     <string name="processing">Processing</string>


### PR DESCRIPTION
## Summary
- add independent settings toggles for generating character and environment images
- conditionally include character and environment image generation steps in the processing pipeline
- localize the new settings labels across supported languages

## Testing
- ./gradlew lint --console=plain
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cb9611bba083258ff908fde7e09bab