### PR TITLE
Simplify Firebase distribution workflow

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -1,42 +1,35 @@
-name: Distribute to Firebase App Distribution
+name: Android CI
 
 on:
   push:
     tags:
-      - 'v*'
+      - '*'
   workflow_dispatch:
 
 jobs:
-  distribute:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: temurin
           java-version: 17
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Set up google-services.json
-        run: |
-          cat <<'EOF' > app/google-services.json
-          ${{ secrets.GOOGLE_SERVICES_JSON }}
-          EOF
-
-      - name: Build release APK
+      - name: Decode google services
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+      - name: Build release
+        env:
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: ./gradlew assembleRelease
-          
-      - name: Upload to Firebase App Distribution
+      - name: Firebase App Distribution
+        if: success()
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           groups: ${{ secrets.FIREBASE_TESTERS_GROUPS }}
           file: app/build/outputs/apk/release/app-release.apk
-          debug: true
-


### PR DESCRIPTION
## Summary
- align workflow triggers with all tags
- update Java setup to v4 action and streamline google-services handling
- build release artifact with required API keys before distributing via Firebase

## Testing
- not run (configuration-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cb9672655483258e0dad62f6bba57e