### PR TITLE
Derive Android version from Git metadata in CI

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -20,10 +20,27 @@ jobs:
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: echo "$GOOGLE_SERVICES_JSON" > app/google-services.json
+      - name: Derive version info
+        id: versioning
+        run: |
+          REF_NAME="${GITHUB_REF_NAME}"
+          if [ -z "$REF_NAME" ]; then
+            REF_NAME="${GITHUB_HEAD_REF}"
+          fi
+          if [ -z "$REF_NAME" ]; then
+            REF_NAME="$(git rev-parse --abbrev-ref HEAD)"
+          fi
+          SANITIZED_REF=$(echo "$REF_NAME" | sed 's/[^A-Za-z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          VERSION_NAME="${SANITIZED_REF}-${SHORT_SHA}"
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "version_code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
       - name: Build release
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          VERSION_NAME: ${{ steps.versioning.outputs.version_name }}
+          VERSION_CODE: ${{ steps.versioning.outputs.version_code }}
         run: ./gradlew assembleRelease
       - name: Firebase App Distribution
         if: success()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
         applicationId "com.immagineran.no"
         minSdk 24
         targetSdk 34
-        versionCode 1
-        versionName "0.1"
+        versionCode readConf('VERSION_CODE', '1').toInteger()
+        versionName readConf('VERSION_NAME', "0.1")
         buildConfigField "String", "GROQ_API_KEY", "\"${readConf('GROQ_API_KEY', '')}\""
         buildConfigField "String", "OPENROUTER_API_KEY", "\"${readConf('OPENROUTER_API_KEY', '')}\""
     }


### PR DESCRIPTION
## Summary
- allow setting the Android version via `VERSION_NAME` and `VERSION_CODE` so CI can override the defaults
- compute a sanitized tag/branch plus short SHA and Gradle run number inside the Firebase distribution workflow
- pass the derived values to the release build so uploaded artifacts use Git-driven version strings

## Testing
- ./gradlew lint
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cd07f3e89c832597b3d9d8af8e55b5