### PR TITLE
Set Groq transcription as default and disable automatic image generation

### DIFF
--- a/app/src/main/java/com/immagineran/no/SettingsManager.kt
+++ b/app/src/main/java/com/immagineran/no/SettingsManager.kt
@@ -19,7 +19,7 @@ object SettingsManager {
         val name = prefs.getString(KEY_TRANSCRIPTION_METHOD, null)
         return name?.let {
             runCatching { TranscriptionMethod.valueOf(it) }.getOrNull()
-        } ?: TranscriptionMethod.LOCAL
+        } ?: TranscriptionMethod.GROQ
     }
 
     fun setTranscriptionMethod(context: Context, method: TranscriptionMethod) {
@@ -60,11 +60,11 @@ object SettingsManager {
         val legacy = legacyAssetGenerationPreference(prefs)
         return when {
             prefs.contains(KEY_GENERATE_CHARACTER_IMAGES) ->
-                prefs.getBoolean(KEY_GENERATE_CHARACTER_IMAGES, true)
+                prefs.getBoolean(KEY_GENERATE_CHARACTER_IMAGES, false)
 
             legacy != null -> legacy
 
-            else -> true
+            else -> false
         }
     }
 
@@ -84,11 +84,11 @@ object SettingsManager {
         val legacy = legacyAssetGenerationPreference(prefs)
         return when {
             prefs.contains(KEY_GENERATE_ENVIRONMENT_IMAGES) ->
-                prefs.getBoolean(KEY_GENERATE_ENVIRONMENT_IMAGES, true)
+                prefs.getBoolean(KEY_GENERATE_ENVIRONMENT_IMAGES, false)
 
             legacy != null -> legacy
 
-            else -> true
+            else -> false
         }
     }
 


### PR DESCRIPTION
## Summary
- default the transcription method to Groq when no user preference is stored
- turn off character and environment image generation by default for new installs while honoring legacy preferences

## Testing
- ./gradlew lint *(fails: missing Android SDK Build-Tools 34 and Platform 34 packages in CI)*
- ./gradlew test *(fails: mergeDebugResources cannot create intermediate resource files in the build directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cd135b9b58832583e74d7a2d0aaf90