### PR TITLE
Ensure extracted story assets prefer English descriptors

### DIFF
--- a/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
+++ b/app/src/main/java/com/immagineran/no/ProcessingPipeline.kt
@@ -88,8 +88,8 @@ class CharacterExtractionStep(
     private val extractor: StoryAssetExtractor = StoryAssetExtractor(appContext),
 ) : ProcessingStep {
     override suspend fun process(context: ProcessingContext) {
-        val story = context.story ?: context.storyEnglish ?: context.storyOriginal ?: return
-        context.characters = extractor.extractCharacters(story)
+        val story = context.storyEnglish ?: context.story ?: context.storyOriginal ?: return
+        context.characters = extractor.extractCharacters(story, context.storyLanguage)
     }
 }
 
@@ -98,8 +98,8 @@ class EnvironmentExtractionStep(
     private val extractor: StoryAssetExtractor = StoryAssetExtractor(appContext),
 ) : ProcessingStep {
     override suspend fun process(context: ProcessingContext) {
-        val story = context.story ?: context.storyEnglish ?: context.storyOriginal ?: return
-        context.environments = extractor.extractEnvironments(story)
+        val story = context.storyEnglish ?: context.story ?: context.storyOriginal ?: return
+        context.environments = extractor.extractEnvironments(story, context.storyLanguage)
     }
 }
 

--- a/app/src/main/java/com/immagineran/no/SceneBuilder.kt
+++ b/app/src/main/java/com/immagineran/no/SceneBuilder.kt
@@ -118,8 +118,8 @@ class SceneBuilder(
         characters: List<CharacterAsset>,
         environments: List<EnvironmentAsset>,
     ): List<Scene> {
-        val charList = characters.joinToString { "${it.name}: ${it.description}" }
-        val envList = environments.joinToString { "${it.name}: ${it.description}" }
+        val charList = characters.joinToString { "${it.displayName}: ${it.displayDescription}" }
+        val envList = environments.joinToString { "${it.displayName}: ${it.displayDescription}" }
         val prompt = """
             Given the following story, characters, and environments, split the story into scenes.
             For each scene provide the narrative text, the environment name, and the list of character names present.
@@ -135,13 +135,13 @@ class SceneBuilder(
             val obj = arr.optJSONObject(i) ?: continue
             val text = obj.optString("text")
             val envName = obj.optString("environment")
-            val env = environments.find { it.name.equals(envName, ignoreCase = true) }
+            val env = environments.find { it.matchesName(envName) }
             val charNames = obj.optJSONArray("characters")
             val chars = mutableListOf<CharacterAsset>()
             if (charNames != null) {
                 for (j in 0 until charNames.length()) {
                     val name = charNames.optString(j)
-                    characters.find { it.name.equals(name, ignoreCase = true) }?.let { chars.add(it) }
+                    characters.find { it.matchesName(name) }?.let { chars.add(it) }
                 }
             }
             if (text.isNotBlank()) {

--- a/app/src/main/java/com/immagineran/no/SceneSteps.kt
+++ b/app/src/main/java/com/immagineran/no/SceneSteps.kt
@@ -24,10 +24,10 @@ class SceneImageGenerationStep(
             val file = File(dir, "scene_${idx}.png")
             val description = buildString {
                 append(scene.text)
-                scene.environment?.let { append(" Environment: ${it.description}.") }
+                scene.environment?.let { append(" Environment: ${it.displayDescription}.") }
                 if (scene.characters.isNotEmpty()) {
                     append(" Characters: ")
-                    append(scene.characters.joinToString { it.description })
+                    append(scene.characters.joinToString { it.displayDescription })
                 }
             }
             val prompt = PromptTemplates.load(appContext, R.raw.scene_image_prompt, style, description)

--- a/app/src/main/java/com/immagineran/no/Story.kt
+++ b/app/src/main/java/com/immagineran/no/Story.kt
@@ -4,13 +4,41 @@ data class CharacterAsset(
     val name: String,
     val description: String,
     val image: String? = null,
-)
+    val nameEnglish: String? = null,
+    val descriptionEnglish: String? = null,
+) {
+    val displayName: String
+        get() = nameEnglish?.takeIf { it.isNotBlank() } ?: name
+
+    val displayDescription: String
+        get() = descriptionEnglish?.takeIf { it.isNotBlank() } ?: description
+
+    fun matchesName(candidate: String): Boolean {
+        if (candidate.equals(nameEnglish, ignoreCase = true)) return true
+        if (candidate.equals(name, ignoreCase = true)) return true
+        return candidate.equals(displayName, ignoreCase = true)
+    }
+}
 
 data class EnvironmentAsset(
     val name: String,
     val description: String,
     val image: String? = null,
-)
+    val nameEnglish: String? = null,
+    val descriptionEnglish: String? = null,
+) {
+    val displayName: String
+        get() = nameEnglish?.takeIf { it.isNotBlank() } ?: name
+
+    val displayDescription: String
+        get() = descriptionEnglish?.takeIf { it.isNotBlank() } ?: description
+
+    fun matchesName(candidate: String): Boolean {
+        if (candidate.equals(nameEnglish, ignoreCase = true)) return true
+        if (candidate.equals(name, ignoreCase = true)) return true
+        return candidate.equals(displayName, ignoreCase = true)
+    }
+}
 
 data class Scene(
     val text: String,

--- a/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
@@ -262,8 +262,8 @@ private fun CharacterList(characters: List<CharacterAsset>) {
             character.image?.let {
                 FullScreenImageData(
                     path = it,
-                    title = character.name,
-                    description = character.description
+                    title = character.displayName,
+                    description = character.displayDescription
                 )
             }
         }
@@ -280,7 +280,7 @@ private fun CharacterList(characters: List<CharacterAsset>) {
                     if (bmp != null) {
                         Image(
                             bitmap = bmp.asImageBitmap(),
-                            contentDescription = c.name,
+                            contentDescription = c.displayName,
                             modifier = Modifier
                                 .size(64.dp)
                                 .clickable {
@@ -292,8 +292,8 @@ private fun CharacterList(characters: List<CharacterAsset>) {
                     }
                 }
                 Column(modifier = Modifier.padding(start = 8.dp)) {
-                    Text(c.name, style = MaterialTheme.typography.subtitle1)
-                    Text(c.description)
+                    Text(c.displayName, style = MaterialTheme.typography.subtitle1)
+                    Text(c.displayDescription)
                     if (c.image == null) {
                         Text(stringResource(R.string.image_generation_error))
                     }
@@ -319,8 +319,8 @@ private fun EnvironmentList(environments: List<EnvironmentAsset>) {
             environment.image?.let {
                 FullScreenImageData(
                     path = it,
-                    title = environment.name,
-                    description = environment.description
+                    title = environment.displayName,
+                    description = environment.displayDescription
                 )
             }
         }
@@ -337,7 +337,7 @@ private fun EnvironmentList(environments: List<EnvironmentAsset>) {
                     if (bmp != null) {
                         Image(
                             bitmap = bmp.asImageBitmap(),
-                            contentDescription = e.name,
+                            contentDescription = e.displayName,
                             modifier = Modifier
                                 .size(64.dp)
                                 .clickable {
@@ -349,8 +349,8 @@ private fun EnvironmentList(environments: List<EnvironmentAsset>) {
                     }
                 }
                 Column(modifier = Modifier.padding(start = 8.dp)) {
-                    Text(e.name, style = MaterialTheme.typography.subtitle1)
-                    Text(e.description)
+                    Text(e.displayName, style = MaterialTheme.typography.subtitle1)
+                    Text(e.displayDescription)
                     if (e.image == null) {
                         Text(stringResource(R.string.image_generation_error))
                     }


### PR DESCRIPTION
## Summary
- pass the English rewrite and source language into character and environment extraction, and update the prompts to require English output
- extend character and environment assets with English descriptor fields and update storage plus UI to favor them while falling back to originals
- propagate the English-aware descriptors through scene building and image generation workflows

## Testing
- `./gradlew --console=plain lint`
- `./gradlew --console=plain test`


------
https://chatgpt.com/codex/tasks/task_e_68cd79620e3c8325a80763142e791cf5