### PR TITLE
Add bilingual scene captions and update scene generation

### DIFF
--- a/app/src/main/java/com/immagineran/no/SceneSteps.kt
+++ b/app/src/main/java/com/immagineran/no/SceneSteps.kt
@@ -8,8 +8,17 @@ class SceneCompositionStep(
     private val builder: SceneBuilder = SceneBuilder(appContext),
 ) : ProcessingStep {
     override suspend fun process(context: ProcessingContext) {
-        val story = context.story ?: context.storyEnglish ?: context.storyOriginal ?: return
-        context.scenes = builder.buildScenes(story, context.characters, context.environments)
+        val storyOriginal = context.storyOriginal ?: context.story
+        val storyEnglish = context.storyEnglish ?: context.story
+        if (storyOriginal.isNullOrBlank() && storyEnglish.isNullOrBlank()) {
+            return
+        }
+        context.scenes = builder.buildScenes(
+            storyOriginal = storyOriginal,
+            storyEnglish = storyEnglish,
+            characters = context.characters,
+            environments = context.environments,
+        )
     }
 }
 
@@ -23,7 +32,7 @@ class SceneImageGenerationStep(
         context.scenes = context.scenes.mapIndexed { idx, scene ->
             val file = File(dir, "scene_${idx}.png")
             val description = buildString {
-                append(scene.text)
+                append(scene.displayCaptionEnglish)
                 scene.environment?.let { append(" Environment: ${it.displayDescription}.") }
                 if (scene.characters.isNotEmpty()) {
                     append(" Characters: ")

--- a/app/src/main/java/com/immagineran/no/Story.kt
+++ b/app/src/main/java/com/immagineran/no/Story.kt
@@ -41,11 +41,18 @@ data class EnvironmentAsset(
 }
 
 data class Scene(
-    val text: String,
+    val captionOriginal: String,
+    val captionEnglish: String,
     val environment: EnvironmentAsset? = null,
     val characters: List<CharacterAsset> = emptyList(),
     val image: String? = null,
-)
+) {
+    val displayCaptionOriginal: String
+        get() = captionOriginal.takeIf { it.isNotBlank() } ?: captionEnglish
+
+    val displayCaptionEnglish: String
+        get() = captionEnglish.takeIf { it.isNotBlank() } ?: captionOriginal
+}
 
 data class Story(
     val id: Long,

--- a/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
@@ -377,7 +377,7 @@ private fun SceneList(scenes: List<Scene>) {
                 FullScreenImageData(
                     path = it,
                     title = null,
-                    description = scene.text
+                    description = scene.displayCaptionEnglish
                 )
             }
         }
@@ -406,7 +406,7 @@ private fun SceneList(scenes: List<Scene>) {
                         )
                     }
                 }
-                Text(s.text, modifier = Modifier.padding(top = 4.dp))
+                Text(s.displayCaptionOriginal, modifier = Modifier.padding(top = 4.dp))
                 if (s.image == null) {
                     Text(stringResource(R.string.image_generation_error))
                 }

--- a/app/src/main/java/com/immagineran/no/StoryRepository.kt
+++ b/app/src/main/java/com/immagineran/no/StoryRepository.kt
@@ -107,7 +107,11 @@ object StoryRepository {
             if (sceneArray != null) {
                 for (j in 0 until sceneArray.length()) {
                     val sObj = sceneArray.optJSONObject(j) ?: continue
-                    val text = sObj.optString("text")
+                    val captionOriginal = sObj.optString("caption_original").takeIf { it.isNotBlank() }
+                        ?: sObj.optString("text").takeIf { it.isNotBlank() }
+                        ?: ""
+                    val captionEnglish = sObj.optString("caption_english").takeIf { it.isNotBlank() }
+                        ?: captionOriginal
                     val envName = sObj.optString("environment")
                     val env = environments.find { environment ->
                         environment.matchesName(envName)
@@ -123,7 +127,8 @@ object StoryRepository {
                     }
                     scenes.add(
                         Scene(
-                            text = text,
+                            captionOriginal = captionOriginal,
+                            captionEnglish = captionEnglish,
                             environment = env,
                             characters = chars,
                             image = sObj.optString("image", null)
@@ -227,7 +232,9 @@ object StoryRepository {
             val sceneArray = JSONArray()
             s.scenes.forEach { scene ->
                 val scObj = JSONObject()
-                scObj.put("text", scene.text)
+                scObj.put("caption_original", scene.captionOriginal)
+                scObj.put("caption_english", scene.captionEnglish)
+                scObj.put("text", scene.displayCaptionOriginal)
                 scene.environment?.let { scObj.put("environment", it.displayName) }
                 val charNames = JSONArray()
                 scene.characters.forEach { c -> charNames.put(c.displayName) }


### PR DESCRIPTION
## Summary
- add original and English caption fields to scenes, persist both in stored stories, and fall back for legacy content
- update scene building prompts to request bilingual captions while aligning characters and environments with the English asset names
- generate image prompts from the English captions but present the original-language captions in the UI

## Testing
- `./gradlew lint --no-daemon --console=plain` *(fails: Android SDK Platform/Build-Tools 34 cannot be installed in the container)*
- `./gradlew test --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68cd7d0a49688325a88b526f088d5ae7