### PR TITLE
Fix fullscreen scene captions to use original language

### DIFF
--- a/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
+++ b/app/src/main/java/com/immagineran/no/StoryDetailScreen.kt
@@ -377,7 +377,7 @@ private fun SceneList(scenes: List<Scene>) {
                 FullScreenImageData(
                     path = it,
                     title = null,
-                    description = scene.displayCaptionEnglish
+                    description = scene.displayCaptionOriginal
                 )
             }
         }


### PR DESCRIPTION
## Summary
- ensure fullscreen scene gallery uses the original language caption instead of the English fallback

## Testing
- `./gradlew lint --console=plain` *(fails: Android SDK Build Tools 34.0.0 installation in container is corrupted and missing aapt)*
- `./gradlew test --console=plain` *(fails: Android SDK Build Tools 34.0.0 installation in container is corrupted and missing aapt)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbb9bb8488325acbc927a50ed6a9c