### PR TITLE
Add story export feature with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ ImmaginarIA is an experimental Android application where players build a collabo
 - `docs/` – Documentation and design notes
 
 See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the high level architecture.
+Export package details are documented in
+[docs/ARCHIVE_FORMAT.md](docs/ARCHIVE_FORMAT.md).
 
 ## Building
 

--- a/app/src/main/java/com/immagineran/no/StoryExporter.kt
+++ b/app/src/main/java/com/immagineran/no/StoryExporter.kt
@@ -1,0 +1,184 @@
+package com.immagineran.no
+
+import android.content.Context
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.Locale
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Creates shareable archives for processed [Story] instances.
+ */
+object StoryExporter {
+    /**
+     * Builds a zip archive containing text, metadata, and referenced images for [story].
+     *
+     * The generated file is stored under `<files>/exports/` and is safe to share through
+     * apps that accept attachments (for example email clients).
+     *
+     * @return The exported file or `null` if no data could be written.
+     */
+    suspend fun export(context: Context, story: Story): File? = withContext(Dispatchers.IO) {
+        val exportDir = File(context.filesDir, "exports").apply { mkdirs() }
+        val sanitizedTitle = sanitize(story.title).ifBlank { "story" }
+        val zipFile = File(exportDir, "${story.id}-${sanitizedTitle}.zip")
+        if (zipFile.exists()) {
+            zipFile.delete()
+        }
+
+        val attachments = mutableListOf<Pair<File, String>>()
+        val metadata = buildMetadata(story, attachments)
+
+        var wroteContent = false
+        runCatching {
+            ZipOutputStream(FileOutputStream(zipFile)).use { zip ->
+                story.storyOriginal?.takeIf { it.isNotBlank() }?.let { original ->
+                    zip.putNextEntry(ZipEntry("text/story_original.txt"))
+                    zip.write(original.toByteArray(Charsets.UTF_8))
+                    zip.closeEntry()
+                    wroteContent = true
+                }
+                story.storyEnglish?.takeIf { it.isNotBlank() && it != story.storyOriginal }?.let { english ->
+                    zip.putNextEntry(ZipEntry("text/story_english.txt"))
+                    zip.write(english.toByteArray(Charsets.UTF_8))
+                    zip.closeEntry()
+                    wroteContent = true
+                }
+
+                zip.putNextEntry(ZipEntry("metadata.json"))
+                zip.write(metadata.toString(2).toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+                wroteContent = true
+
+                attachments.forEach { (file, entryName) ->
+                    if (file.exists()) {
+                        zip.putNextEntry(ZipEntry(entryName))
+                        BufferedInputStream(FileInputStream(file)).use { input ->
+                            input.copyTo(zip)
+                        }
+                        zip.closeEntry()
+                        wroteContent = true
+                    }
+                }
+            }
+        }.getOrElse {
+            zipFile.delete()
+            return@withContext null
+        }
+
+        return@withContext zipFile.takeIf { wroteContent && it.exists() }
+    }
+
+    private fun buildMetadata(story: Story, attachments: MutableList<Pair<File, String>>): JSONObject {
+        val metadata = JSONObject()
+        metadata.put("id", story.id)
+        metadata.put("title", story.title)
+        metadata.put("timestamp", story.timestamp)
+        story.language?.let { metadata.put("language", it) }
+        metadata.put("processed", story.processed)
+        story.storyOriginal?.let { metadata.put("story_original", it) }
+        story.storyEnglish?.let { metadata.put("story_english", it) }
+        if (story.content.isNotBlank()) {
+            metadata.put("content", story.content)
+        }
+
+        if (story.segments.isNotEmpty()) {
+            val segmentsArray = JSONArray()
+            story.segments.forEachIndexed { index, path ->
+                val segmentObj = JSONObject()
+                segmentObj.put("source_path", path)
+                val file = File(path)
+                if (file.exists()) {
+                    val entryName = "audio/segment_${index}.${file.extension.ifBlank { "wav" }}"
+                    attachments.add(file to entryName)
+                    segmentObj.put("file", entryName)
+                }
+                segmentsArray.put(segmentObj)
+            }
+            metadata.put("segments", segmentsArray)
+        }
+
+        val characters = JSONArray()
+        story.characters.forEachIndexed { index, character ->
+            val characterObj = JSONObject()
+            characterObj.put("name", character.name)
+            characterObj.put("description", character.description)
+            character.nameEnglish?.let { characterObj.put("name_english", it) }
+            character.descriptionEnglish?.let { characterObj.put("description_english", it) }
+            character.image?.let { path ->
+                val file = File(path)
+                if (file.exists()) {
+                    val entryName = imageEntryName("characters", index, character.displayName, file)
+                    attachments.add(file to entryName)
+                    characterObj.put("image", entryName)
+                }
+            }
+            characters.put(characterObj)
+        }
+        metadata.put("characters", characters)
+
+        val environments = JSONArray()
+        story.environments.forEachIndexed { index, environment ->
+            val environmentObj = JSONObject()
+            environmentObj.put("name", environment.name)
+            environmentObj.put("description", environment.description)
+            environment.nameEnglish?.let { environmentObj.put("name_english", it) }
+            environment.descriptionEnglish?.let { environmentObj.put("description_english", it) }
+            environment.image?.let { path ->
+                val file = File(path)
+                if (file.exists()) {
+                    val entryName = imageEntryName("environments", index, environment.displayName, file)
+                    attachments.add(file to entryName)
+                    environmentObj.put("image", entryName)
+                }
+            }
+            environments.put(environmentObj)
+        }
+        metadata.put("environments", environments)
+
+        val scenes = JSONArray()
+        story.scenes.forEachIndexed { index, scene ->
+            val sceneObj = JSONObject()
+            sceneObj.put("caption_original", scene.captionOriginal)
+            sceneObj.put("caption_english", scene.captionEnglish)
+            scene.environment?.let { environment ->
+                sceneObj.put("environment", environment.displayName)
+            }
+            if (scene.characters.isNotEmpty()) {
+                val characterArray = JSONArray()
+                scene.characters.forEach { characterArray.put(it.displayName) }
+                sceneObj.put("characters", characterArray)
+            }
+            scene.image?.let { path ->
+                val file = File(path)
+                if (file.exists()) {
+                    val entryName = imageEntryName("scenes", index, scene.displayCaptionEnglish, file)
+                    attachments.add(file to entryName)
+                    sceneObj.put("image", entryName)
+                }
+            }
+            scenes.put(sceneObj)
+        }
+        metadata.put("scenes", scenes)
+        return metadata
+    }
+
+    private fun imageEntryName(category: String, index: Int, name: String?, file: File): String {
+        val sanitized = sanitize(name ?: "${category}_${index}").ifBlank { "${category}_${index}" }
+        val extension = file.extension.takeIf { it.isNotBlank() } ?: "png"
+        return "images/${category}/${index + 1}-${sanitized}.${extension}"
+    }
+
+    private fun sanitize(value: String): String {
+        return value.lowercase(Locale.US)
+            .replace("[^a-z0-9]+".toRegex(), "-")
+            .trim('-')
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,4 +47,8 @@
     <string name="save_title">Save title</string>
     <string name="processing">Processing</string>
     <string name="processing_complete">Processing complete</string>
+    <string name="export_story">Export</string>
+    <string name="share_story_chooser_title">Share “%1$s”</string>
+    <string name="export_story_message">Storyboard exported from ImmaginarIA: %1$s</string>
+    <string name="export_story_error">Unable to export this story.</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <files-path name="logs" path="." />
+    <files-path name="exports" path="exports/" />
 </paths>

--- a/docs/ARCHIVE_FORMAT.md
+++ b/docs/ARCHIVE_FORMAT.md
@@ -1,0 +1,71 @@
+# Story export format
+
+Completed stories can be exported as a `.zip` archive from the Finished Stories
+list. The archive contains the following top-level entries:
+
+- `metadata.json` – structured description of the story and exported assets.
+- `text/` – folder with plain-text versions of the story in different
+  languages.
+- `images/` – folders containing the generated artwork.
+- `audio/` – optional folder with recorded audio segments when available.
+
+## metadata.json
+
+The `metadata.json` file is encoded as UTF-8 and exposes the content that the
+application needs to reconstruct the storyboard. Its schema is:
+
+- `id`: Numeric identifier of the story.
+- `title`: The story title.
+- `timestamp`: Unix epoch milliseconds when the story was created.
+- `language`: Optional ISO language tag that represents the original language
+  of the story.
+- `processed`: Indicates whether the story finished processing when exported.
+- `story_original`: Original-language text used to build the storyboard.
+- `story_english`: English rewrite of the story when available.
+- `content`: Raw JSON response from the stitching model, if present.
+- `segments`: Array describing the recorded input. Each item contains:
+  - `source_path`: Local path of the original recording on the device.
+  - `file`: Relative path inside the archive (for example
+    `"audio/segment_0.wav"`) when the audio file is exported.
+- `characters`: Array of character descriptors. Each item contains:
+  - `name`: Character name in the working language.
+  - `description`: Character description in the working language.
+  - `name_english`: Optional English name.
+  - `description_english`: Optional English description.
+  - `image`: Relative path to the exported character image when present.
+- `environments`: Array of environment descriptors mirroring the structure of
+  `characters`.
+- `scenes`: Array of storyboard scenes. Each item contains:
+  - `caption_original`: Scene description in the original language.
+  - `caption_english`: English version of the caption.
+  - `environment`: Display name of the referenced environment asset.
+  - `characters`: Array of character display names appearing in the scene.
+  - `image`: Relative path to the exported scene image when present.
+
+All relative image and audio paths match the file names stored in the archive.
+
+## Text files
+
+The `text` directory contains human-readable story content:
+
+- `story_original.txt`: Original language story.
+- `story_english.txt`: English rewrite when it differs from the original.
+
+Files are encoded as UTF-8 and can be opened by any text editor.
+
+## Image and audio assets
+
+Every exported image is written under `images/<category>/` where `<category>`
+can be `characters`, `environments`, or `scenes`. File names include an index
+and a sanitized version of the asset name (for example,
+`images/scenes/1-forest-entrance.png`).
+
+If audio segments were captured during story creation, they are exported in the
+`audio/` directory using their original file extensions when available. When no
+extension is present, `.wav` is used by default.
+
+## File location and sharing
+
+Archives are stored in the application files directory under `exports/` before
+being shared through Android's attachment intents. Users can attach the archive
+from email clients or other apps that support sending files.


### PR DESCRIPTION
## Summary
- add a StoryExporter that packages processed stories into shareable zip archives
- expose an Export action for finished stories that shares the generated archive
- document the archive structure and update supporting resources

## Testing
- ./gradlew lint --console=plain --no-daemon *(fails: command cancelled due to long runtime in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28a4bc5fc832593fe42bbd18fe6c1